### PR TITLE
Bumping async-search-client from 0.6.0 to 0.6.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -16,7 +16,7 @@ python-versions = "*"
 
 [[package]]
 name = "async-search-client"
-version = "0.6.0"
+version = "0.6.1"
 description = "A Python async client for the MeiliSearch API"
 category = "main"
 optional = false
@@ -123,6 +123,9 @@ description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.dependencies]
+toml = {version = "*", optional = true, markers = "extra == \"toml\""}
 
 [package.extras]
 toml = ["toml"]
@@ -447,14 +450,14 @@ testing = ["coverage", "hypothesis (>=5.7.1)"]
 
 [[package]]
 name = "pytest-cov"
-version = "2.11.1"
+version = "2.12.0"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
-coverage = ">=5.2.1"
+coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
@@ -625,7 +628,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "65abcf37873477e453297701a906f8932fa4f19f50c83c8522857ebf2f543c2d"
+content-hash = "55c97ed52dcb0e33458d55892d387140c8955c74e8321a33f23562dedfd509c1"
 
 [metadata.files]
 aiofiles = [
@@ -637,8 +640,8 @@ appdirs = [
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
 ]
 async-search-client = [
-    {file = "async-search-client-0.6.0.tar.gz", hash = "sha256:5cf3979c9b31c0425dd4cae0360b6a8766f7eeafe908bffdd061477f6b3882b6"},
-    {file = "async_search_client-0.6.0-py3-none-any.whl", hash = "sha256:9e636860a55a6d68f297f827c3f4aa617f0a4d50924965a14baaa510f2757393"},
+    {file = "async-search-client-0.6.1.tar.gz", hash = "sha256:e0bff75032a2df1d9fd865efbd5b37d560d9b4aa4fc1807af6db321f0caaa89a"},
+    {file = "async_search_client-0.6.1-py3-none-any.whl", hash = "sha256:34a2521ffef9e40c20c591325dd9b7c8e92b2d75d63ea78b1916733653e0d4ec"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -872,8 +875,8 @@ pytest-asyncio = [
     {file = "pytest_asyncio-0.15.1-py3-none-any.whl", hash = "sha256:3042bcdf1c5d978f6b74d96a151c4cfb9dcece65006198389ccd7e6c60eb1eea"},
 ]
 pytest-cov = [
-    {file = "pytest-cov-2.11.1.tar.gz", hash = "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7"},
-    {file = "pytest_cov-2.11.1-py2.py3-none-any.whl", hash = "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"},
+    {file = "pytest-cov-2.12.0.tar.gz", hash = "sha256:8535764137fecce504a49c2b742288e3d34bc09eed298ad65963616cc98fd45e"},
+    {file = "pytest_cov-2.12.0-py2.py3-none-any.whl", hash = "sha256:95d4933dcbbacfa377bb60b29801daa30d90c33981ab2a79e9ab4452c165066e"},
 ]
 python-dotenv = [
     {file = "python-dotenv-0.17.1.tar.gz", hash = "sha256:b1ae5e9643d5ed987fc57cc2583021e38db531946518130777734f9589b3141f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meilisearch-fastapi"
-version = "0.1.1"
+version = "0.1.2"
 description = "MeiliSearch integration with FastAPI"
 authors = ["Paul Sanders <psanders1@gmail.com>"]
 license = "MIT"
@@ -20,7 +20,7 @@ include = ["meilisearch_fastapi/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-async-search-client = "^0.6.0"
+async-search-client = "^0.6.1"
 fastapi = "^0.65.1"
 python-dotenv = "^0.17.1"
 


### PR DESCRIPTION
Bumping async-search-client from 0.6.0 to 0.6.1 for the more flexable handling of iso dates