### PR TITLE
Moved mypy settings to pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       language_version: python3
       args: [--line-length=100]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v0.901
     hooks:
     - id: mypy
       files: meilisearch_fastapi/

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,0 @@
-[mypy]
-disallow_untyped_defs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,6 @@ src_paths = ["meilisearch_fastapi", "tests"]
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "--cov=meilisearch_fastapi"
+
+[tool.mypy]
+disallow_untyped_defs = true


### PR DESCRIPTION
MyPy allows setting to be in the pyproject.toml file starting with v0.900 so moving them there and removing the mypy.ini file.