### PR TITLE
Changed async-search-client dependency to meilisearch-python-async

### DIFF
--- a/meilisearch_fastapi/models/settings.py
+++ b/meilisearch_fastapi/models/settings.py
@@ -1,4 +1,4 @@
-from async_search_client.models import MeiliSearchSettings
+from meilisearch_python_async.models import MeiliSearchSettings
 
 
 class MeiliSearchIndexSettings(MeiliSearchSettings):

--- a/meilisearch_fastapi/routes/document_routes.py
+++ b/meilisearch_fastapi/routes/document_routes.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Dict, List
 
-from async_search_client import Client
-from async_search_client.models import UpdateId
 from fastapi import APIRouter, Depends, HTTPException
+from meilisearch_python_async import Client
+from meilisearch_python_async.models import UpdateId
 
 from meilisearch_fastapi._config import MeiliSearchConfig, get_config
 from meilisearch_fastapi.models.document_info import (

--- a/meilisearch_fastapi/routes/index_routes.py
+++ b/meilisearch_fastapi/routes/index_routes.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import List
 
-from async_search_client import Client
-from async_search_client.models import IndexBase, IndexInfo, IndexStats, UpdateId
 from fastapi import APIRouter, Depends, HTTPException
+from meilisearch_python_async import Client
+from meilisearch_python_async.models import IndexBase, IndexInfo, IndexStats, UpdateId
 
 from meilisearch_fastapi._config import MeiliSearchConfig, get_config
 from meilisearch_fastapi.models.index import (

--- a/meilisearch_fastapi/routes/meilisearch_routes.py
+++ b/meilisearch_fastapi/routes/meilisearch_routes.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from async_search_client import Client
-from async_search_client.models import ClientStats, Keys, Version  # Health,
 from fastapi import APIRouter, Depends
+from meilisearch_python_async import Client
+from meilisearch_python_async.models import ClientStats, Keys, Version  # Health,
 
 from meilisearch_fastapi._config import MeiliSearchConfig, get_config
 

--- a/meilisearch_fastapi/routes/search_routes.py
+++ b/meilisearch_fastapi/routes/search_routes.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from async_search_client import Client
-from async_search_client.models import SearchResults
 from fastapi import APIRouter, Depends
+from meilisearch_python_async import Client
+from meilisearch_python_async.models import SearchResults
 
 from meilisearch_fastapi._config import MeiliSearchConfig, get_config
 from meilisearch_fastapi.models.search_parameters import SearchParameters

--- a/meilisearch_fastapi/routes/settings_routes.py
+++ b/meilisearch_fastapi/routes/settings_routes.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from async_search_client import Client
-from async_search_client.models import MeiliSearchSettings, UpdateId
 from fastapi import APIRouter, Depends
+from meilisearch_python_async import Client
+from meilisearch_python_async.models import MeiliSearchSettings, UpdateId
 
 from meilisearch_fastapi._config import MeiliSearchConfig, get_config
 from meilisearch_fastapi.models.settings import MeiliSearchIndexSettings

--- a/poetry.lock
+++ b/poetry.lock
@@ -47,20 +47,6 @@ typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
 
 [[package]]
-name = "async-search-client"
-version = "0.8.1"
-description = "A Python async client for the MeiliSearch API"
-category = "main"
-optional = false
-python-versions = ">=3.7,<4.0"
-
-[package.dependencies]
-aiofiles = ">=0.7.0,<0.8.0"
-camel-converter = ">=1.0.0,<2.0.0"
-httpx = ">=0.17,<0.19"
-pydantic = ">=1.8,<2.0"
-
-[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -318,6 +304,20 @@ description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "meilisearch-python-async"
+version = "0.10.0"
+description = "A Python async client for the MeiliSearch API"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+aiofiles = ">=0.7.0,<0.8.0"
+camel-converter = ">=1.0.0,<2.0.0"
+httpx = ">=0.17,<0.19"
+pydantic = ">=1.8,<2.0"
 
 [[package]]
 name = "mypy"
@@ -669,7 +669,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "d34ce10e2c5d05a16c6a00ce696ba46d7413bdfbaba0ec98917727b89028825e"
+content-hash = "9f0cf1cb4bc0d8282fc8383567df66059000aadd6d418de96f0fed6c72f193ea"
 
 [metadata.files]
 aiofiles = [
@@ -687,10 +687,6 @@ appdirs = [
 asgiref = [
     {file = "asgiref-3.3.4-py3-none-any.whl", hash = "sha256:92906c611ce6c967347bbfea733f13d6313901d54dcca88195eaeb52b2a8e8ee"},
     {file = "asgiref-3.3.4.tar.gz", hash = "sha256:d1216dfbdfb63826470995d31caed36225dcaf34f182e0fa257a4dd9e86f1b78"},
-]
-async-search-client = [
-    {file = "async-search-client-0.8.1.tar.gz", hash = "sha256:b70b362361c8b332b81faeffa2f2f0dc5d8f1be2465f87d9fc76fcc4b0091208"},
-    {file = "async_search_client-0.8.1-py3-none-any.whl", hash = "sha256:454b17298fba454a9bac021275caa5b651689fadff2a1d7099c80ebd2df4423e"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -736,6 +732,9 @@ coverage = [
     {file = "coverage-5.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083"},
     {file = "coverage-5.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5"},
     {file = "coverage-5.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81"},
+    {file = "coverage-5.5-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6"},
+    {file = "coverage-5.5-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0"},
+    {file = "coverage-5.5-cp310-cp310-win_amd64.whl", hash = "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae"},
     {file = "coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb"},
     {file = "coverage-5.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160"},
     {file = "coverage-5.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"},
@@ -826,6 +825,10 @@ isort = [
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+meilisearch-python-async = [
+    {file = "meilisearch-python-async-0.10.0.tar.gz", hash = "sha256:28e39144caec7ddc34e3bc9c92362c5e5bb22856eecb95f04816d29f96e7c39a"},
+    {file = "meilisearch_python_async-0.10.0-py3-none-any.whl", hash = "sha256:191bfb277c187e8277f77ece5ab60624b02a7a8a9e10d545e1a3517361220eb6"},
 ]
 mypy = [
     {file = "mypy-0.910-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457"},
@@ -939,18 +942,26 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
     {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
     {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
     {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
     {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
     {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
     {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
     {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
     {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meilisearch-fastapi"
-version = "0.4.0"
+version = "0.5.0"
 description = "MeiliSearch integration with FastAPI"
 authors = ["Paul Sanders <psanders1@gmail.com>"]
 license = "MIT"
@@ -20,9 +20,9 @@ include = ["meilisearch_fastapi/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-async-search-client = "^0.8.0"
 fastapi = "^0.65.1"
 pydantic = {version = "^1.8.2", extras = ["dotenv"]}
+meilisearch-python-async = "^0.10.0"
 
 [tool.poetry.dev-dependencies]
 black = "^21.6b0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,9 @@ import json
 from pathlib import Path
 
 import pytest
-from async_search_client import Client
 from fastapi import APIRouter, FastAPI
 from httpx import AsyncClient
+from meilisearch_python_async import Client
 
 from meilisearch_fastapi.routes import (
     document_routes,

--- a/tests/test_document_routes.py
+++ b/tests/test_document_routes.py
@@ -1,7 +1,7 @@
 from math import ceil
 
 import pytest
-from async_search_client.errors import MeiliSearchApiError
+from meilisearch_python_async.errors import MeiliSearchApiError
 
 
 @pytest.mark.asyncio

--- a/tests/test_index_routes.py
+++ b/tests/test_index_routes.py
@@ -1,5 +1,5 @@
 import pytest
-from async_search_client.models import MeiliSearchSettings
+from meilisearch_python_async.models import MeiliSearchSettings
 
 
 @pytest.fixture


### PR DESCRIPTION
The async-search-client package was renamed to meilisearch-python-async. Because this package relies heavily on that package the dependency here was updated to the new package.