### PR TITLE
Adding cache to get_config

### DIFF
--- a/meilisearch_fastapi/_config.py
+++ b/meilisearch_fastapi/_config.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import Optional
 
 from pydantic import BaseSettings
@@ -11,5 +12,6 @@ class MeiliSearchConfig(BaseSettings):
         env_file = ".env"
 
 
+@lru_cache(maxsize=1)
 def get_config() -> MeiliSearchConfig:
     return MeiliSearchConfig()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,8 @@ def test_config_no_key(meilisearch_url, master_key, monkeypatch):
     # make sure there isn't an environmet vairable present
     monkeypatch.delenv("MEILISEARCH_API_KEY", raising=False)
 
+    get_config.cache_clear()
+
     config = get_config()
 
     assert config.meilisearch_api_key is None
@@ -25,6 +27,8 @@ def test_config_no_key(meilisearch_url, master_key, monkeypatch):
 def test_config_no_url(meilisearch_url, monkeypatch):
     # make sure there isn't an environmet vairable present
     monkeypatch.delenv("MEILISEARCH_URL", raising=False)
+
+    get_config.cache_clear()
 
     with pytest.raises(ValueError):
         get_config()


### PR DESCRIPTION
`get_config` is called on every route and never changes after initially being set so adding a cache to store it's value.