### PR TITLE
Adding query parameters to get documents route

### DIFF
--- a/meilisearch_fastapi/routes/document_routes.py
+++ b/meilisearch_fastapi/routes/document_routes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from meilisearch_python_async import Client
@@ -79,10 +79,21 @@ async def get_document(
 
 
 @router.get("/{uid}", response_model=List[Dict])
-async def get_documents(uid: str, config: MeiliSearchConfig = Depends(get_config)) -> list[dict]:
+async def get_documents(
+    uid: str,
+    limit: int = 20,
+    offset: int = 0,
+    attributes_to_retrieve: Optional[str] = None,
+    config: MeiliSearchConfig = Depends(get_config),
+) -> list[dict]:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
-        documents = await index.get_documents()
+
+        documents = await index.get_documents(
+            offset=offset,
+            limit=limit,
+            attributes_to_retrieve=attributes_to_retrieve,
+        )
 
         if documents is None:
             raise HTTPException(404, "No documents found")

--- a/tests/test_document_routes.py
+++ b/tests/test_document_routes.py
@@ -107,6 +107,19 @@ async def test_get_documents_populated(test_client, index_with_documents):
 
 
 @pytest.mark.asyncio
+async def test_get_documents_offset_optional_params(test_client, index_with_documents):
+    uid, _ = index_with_documents
+    response = await test_client.get(f"/documents/{uid}")
+    assert len(response.json()) == 20
+
+    response_offset_limit = await test_client.get(
+        f"documents/{uid}?limit=3&offset=1&attributes_to_retrieve=title"
+    )
+    assert len(response_offset_limit.json()) == 3
+    assert response_offset_limit.json()[0]["title"] == response.json()[1]["title"]
+
+
+@pytest.mark.asyncio
 async def test_update_documents(test_client, index_with_documents, small_movies):
     uid, index = index_with_documents
     response = await test_client.get(f"documents/{uid}")


### PR DESCRIPTION
There was no way to pass search parameters to `get_documents`. This PR adds that ability.