### PR TITLE
Update for MeiliSearch v0.25.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,8 +76,7 @@ jobs:
     - name: Install Dependencies
       run: poetry install
     - name: MeiliSearch (latest version) setup with Docker
-      # run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key=masterKey
-      run: docker run -d -p 7700:7700 getmeili/meilisearch:v0.25.0rc2 ./meilisearch --no-analytics=true --master-key=masterKey
+      run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key=masterKey
     - name: Test with pytest
       run: |
         poetry run pytest --cov=meilisearch_fastapi --cov-report=xml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,8 @@ jobs:
     - name: Install Dependencies
       run: poetry install
     - name: MeiliSearch (latest version) setup with Docker
-      run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key=masterKey
+      # run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key=masterKey
+      run: docker run -d -p 7700:7700 getmeili/meilisearch:v0.25.0rc2 ./meilisearch --no-analytics=true --master-key=masterKey
     - name: Test with pytest
       run: |
         poetry run pytest --cov=meilisearch_fastapi --cov-report=xml

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Now the MeiliSearch routes will be available in your FastAPI app. Documentation 
 
 ## Compatibility with MeiliSearch
 
-This package only guarantees the compatibility with [version v0.24 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.24.0).
+This package only guarantees the compatibility with [version v0.25 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.25.0).
 
 ## Contributing
 

--- a/meilisearch_fastapi/routes/document_routes.py
+++ b/meilisearch_fastapi/routes/document_routes.py
@@ -1,10 +1,8 @@
-from __future__ import annotations
-
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from meilisearch_python_async import Client
-from meilisearch_python_async.models.update import UpdateId
+from meilisearch_python_async.models.task import TaskId
 
 from meilisearch_fastapi._config import MeiliSearchConfig, get_config
 from meilisearch_fastapi.models.document_info import (
@@ -17,10 +15,10 @@ from meilisearch_fastapi.models.document_info import (
 router = APIRouter()
 
 
-@router.post("/", response_model=UpdateId, status_code=202, tags=["MeiliSearch Documents"])
+@router.post("/", response_model=TaskId, status_code=202, tags=["MeiliSearch Documents"])
 async def add_documents(
     document_info: DocumentInfo, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(document_info.uid)
 
@@ -28,11 +26,11 @@ async def add_documents(
 
 
 @router.post(
-    "/auto-batch", response_model=List[UpdateId], status_code=202, tags=["MeiliSearch Documents"]
+    "/auto-batch", response_model=List[TaskId], status_code=202, tags=["MeiliSearch Documents"]
 )
 async def add_documents_auto_batch(
     document_info: DocumentInfoAutoBatch, config: MeiliSearchConfig = Depends(get_config)
-) -> list[UpdateId]:
+) -> List[TaskId]:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(document_info.uid)
 
@@ -49,11 +47,11 @@ async def add_documents_auto_batch(
 
 
 @router.post(
-    "/batches", response_model=List[UpdateId], status_code=202, tags=["MeiliSearch Documents"]
+    "/batches", response_model=List[TaskId], status_code=202, tags=["MeiliSearch Documents"]
 )
 async def add_documents_in_batches(
     document_info: DocumentInfoBatches, config: MeiliSearchConfig = Depends(get_config)
-) -> list[UpdateId]:
+) -> List[TaskId]:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(document_info.uid)
 
@@ -64,10 +62,8 @@ async def add_documents_in_batches(
         )
 
 
-@router.delete("/{uid}", response_model=UpdateId, status_code=202, tags=["MeiliSearch Documents"])
-async def delete_all_documents(
-    uid: str, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+@router.delete("/{uid}", response_model=TaskId, status_code=202, tags=["MeiliSearch Documents"])
+async def delete_all_documents(uid: str, config: MeiliSearchConfig = Depends(get_config)) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
 
@@ -75,21 +71,21 @@ async def delete_all_documents(
 
 
 @router.delete(
-    "/{uid}/{document_id}", response_model=UpdateId, status_code=202, tags=["MeiliSearch Documents"]
+    "/{uid}/{document_id}", response_model=TaskId, status_code=202, tags=["MeiliSearch Documents"]
 )
 async def delete_document(
     uid: str, document_id: str, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
 
         return await index.delete_document(document_id)
 
 
-@router.post("/delete", response_model=UpdateId, status_code=202, tags=["MeiliSearch Documents"])
+@router.post("/delete", response_model=TaskId, status_code=202, tags=["MeiliSearch Documents"])
 async def delete_documents(
     documents: DocumentDelete, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(documents.uid)
 
@@ -113,7 +109,7 @@ async def get_documents(
     offset: int = 0,
     attributes_to_retrieve: Optional[str] = None,
     config: MeiliSearchConfig = Depends(get_config),
-) -> list[dict]:
+) -> List[dict]:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
 
@@ -129,10 +125,10 @@ async def get_documents(
         return documents
 
 
-@router.put("/", response_model=UpdateId, status_code=202, tags=["MeiliSearch Documents"])
+@router.put("/", response_model=TaskId, status_code=202, tags=["MeiliSearch Documents"])
 async def update_documents(
     document_info: DocumentInfo, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(document_info.uid)
 
@@ -140,11 +136,11 @@ async def update_documents(
 
 
 @router.put(
-    "/auto-batch", response_model=List[UpdateId], status_code=202, tags=["MeiliSearch Documents"]
+    "/auto-batch", response_model=List[TaskId], status_code=202, tags=["MeiliSearch Documents"]
 )
 async def update_documents_auto_batch(
     document_info: DocumentInfoAutoBatch, config: MeiliSearchConfig = Depends(get_config)
-) -> list[UpdateId]:
+) -> List[TaskId]:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(document_info.uid)
 
@@ -161,11 +157,11 @@ async def update_documents_auto_batch(
 
 
 @router.put(
-    "/batches", response_model=List[UpdateId], status_code=202, tags=["MeiliSearch Documents"]
+    "/batches", response_model=List[TaskId], status_code=202, tags=["MeiliSearch Documents"]
 )
 async def update_documents_in_batches(
     document_info: DocumentInfoBatches, config: MeiliSearchConfig = Depends(get_config)
-) -> list[UpdateId]:
+) -> List[TaskId]:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(document_info.uid)
 

--- a/meilisearch_fastapi/routes/index_routes.py
+++ b/meilisearch_fastapi/routes/index_routes.py
@@ -99,7 +99,7 @@ async def delete_if_exists(uid: str, config: MeiliSearchConfig = Depends(get_con
         return 204
 
 
-@router.delete("/{uid}", response_model=TaskStatus, status_code=204, tags=["MeiliSearch Index"])
+@router.delete("/{uid}", response_model=TaskStatus, tags=["MeiliSearch Index"])
 async def delete_index(uid: str, config: MeiliSearchConfig = Depends(get_config)) -> TaskStatus:
     async with Client(config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)

--- a/meilisearch_fastapi/routes/index_routes.py
+++ b/meilisearch_fastapi/routes/index_routes.py
@@ -3,7 +3,7 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException
 from meilisearch_python_async import Client
 from meilisearch_python_async.models.index import IndexBase, IndexInfo, IndexStats
-from meilisearch_python_async.models.task import TaskId
+from meilisearch_python_async.models.task import TaskId, TaskStatus
 
 from meilisearch_fastapi._config import MeiliSearchConfig, get_config
 from meilisearch_fastapi.models.index import (
@@ -99,8 +99,8 @@ async def delete_if_exists(uid: str, config: MeiliSearchConfig = Depends(get_con
         return 204
 
 
-@router.delete("/{uid}", status_code=204, tags=["MeiliSearch Index"])
-async def delete_index(uid: str, config: MeiliSearchConfig = Depends(get_config)) -> int:
+@router.delete("/{uid}", response_model=TaskStatus, status_code=204, tags=["MeiliSearch Index"])
+async def delete_index(uid: str, config: MeiliSearchConfig = Depends(get_config)) -> TaskStatus:
     async with Client(config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
         return await index.delete()

--- a/meilisearch_fastapi/routes/index_routes.py
+++ b/meilisearch_fastapi/routes/index_routes.py
@@ -1,11 +1,9 @@
-from __future__ import annotations
-
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
 from meilisearch_python_async import Client
 from meilisearch_python_async.models.index import IndexBase, IndexInfo, IndexStats
-from meilisearch_python_async.models.update import UpdateId
+from meilisearch_python_async.models.task import TaskId
 
 from meilisearch_fastapi._config import MeiliSearchConfig, get_config
 from meilisearch_fastapi.models.index import (
@@ -49,14 +47,14 @@ async def create_index(
 
 @router.delete(
     "/filterable-attributes/{uid}",
-    response_model=UpdateId,
+    response_model=TaskId,
     status_code=202,
     tags=["MeiliSearch Index"],
 )
 async def delete_filterable_attributes(
     uid: str,
     config: MeiliSearchConfig = Depends(get_config),
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
 
@@ -65,13 +63,13 @@ async def delete_filterable_attributes(
 
 @router.delete(
     "/displayed-attributes/{uid}",
-    response_model=UpdateId,
+    response_model=TaskId,
     status_code=202,
     tags=["MeiliSearch Index"],
 )
 async def delete_displayed_attributes(
     uid: str, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
 
@@ -80,13 +78,13 @@ async def delete_displayed_attributes(
 
 @router.delete(
     "/attributes/distinct/{uid}",
-    response_model=UpdateId,
+    response_model=TaskId,
     status_code=202,
     tags=["MeiliSearch Index"],
 )
 async def delete_distinct_attribute(
     uid: str, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
 
@@ -109,11 +107,9 @@ async def delete_index(uid: str, config: MeiliSearchConfig = Depends(get_config)
 
 
 @router.delete(
-    "/ranking-rules/{uid}", response_model=UpdateId, status_code=202, tags=["MeiliSearch Index"]
+    "/ranking-rules/{uid}", response_model=TaskId, status_code=202, tags=["MeiliSearch Index"]
 )
-async def delete_ranking_rules(
-    uid: str, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+async def delete_ranking_rules(uid: str, config: MeiliSearchConfig = Depends(get_config)) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
 
@@ -122,13 +118,13 @@ async def delete_ranking_rules(
 
 @router.delete(
     "/searchable-attributes/{uid}",
-    response_model=UpdateId,
+    response_model=TaskId,
     status_code=202,
     tags=["MeiliSearch Index"],
 )
 async def delete_searchable_attributes(
     uid: str, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
 
@@ -137,13 +133,13 @@ async def delete_searchable_attributes(
 
 @router.delete(
     "/sortable-attributes/{uid}",
-    response_model=UpdateId,
+    response_model=TaskId,
     status_code=202,
     tags=["MeiliSearch Index"],
 )
 async def delete_sortable_attributes(
     uid: str, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
 
@@ -151,9 +147,9 @@ async def delete_sortable_attributes(
 
 
 @router.delete(
-    "/stop-words/{uid}", response_model=UpdateId, status_code=202, tags=["MeiliSearch Index"]
+    "/stop-words/{uid}", response_model=TaskId, status_code=202, tags=["MeiliSearch Index"]
 )
-async def delete_stop_words(uid: str, config: MeiliSearchConfig = Depends(get_config)) -> UpdateId:
+async def delete_stop_words(uid: str, config: MeiliSearchConfig = Depends(get_config)) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
 
@@ -161,9 +157,9 @@ async def delete_stop_words(uid: str, config: MeiliSearchConfig = Depends(get_co
 
 
 @router.delete(
-    "/synonyms/{uid}", response_model=UpdateId, status_code=202, tags=["MeiliSearch Index"]
+    "/synonyms/{uid}", response_model=TaskId, status_code=202, tags=["MeiliSearch Index"]
 )
-async def delete_synonyms(uid: str, config: MeiliSearchConfig = Depends(get_config)) -> UpdateId:
+async def delete_synonyms(uid: str, config: MeiliSearchConfig = Depends(get_config)) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
 
@@ -246,7 +242,7 @@ async def get_stats(uid: str, config: MeiliSearchConfig = Depends(get_config)) -
 @router.get("/", response_model=List[IndexInfo], tags=["MeiliSearch Index"])
 async def get_indexes(
     config: MeiliSearchConfig = Depends(get_config),
-) -> list[IndexInfo]:
+) -> List[IndexInfo]:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         indexes = await client.get_raw_indexes()
 
@@ -310,12 +306,12 @@ async def get_synonyms(uid: str, config: MeiliSearchConfig = Depends(get_config)
 
 
 @router.put(
-    "/filterable-attributes", response_model=UpdateId, status_code=202, tags=["MeiliSearch Index"]
+    "/filterable-attributes", response_model=TaskId, status_code=202, tags=["MeiliSearch Index"]
 )
 async def update_filterable_attributes(
     filterable_attributes: FilterableAttributesWithUID,
     config: MeiliSearchConfig = Depends(get_config),
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(filterable_attributes.uid)
         attributes = filterable_attributes.filterable_attributes or []
@@ -324,11 +320,11 @@ async def update_filterable_attributes(
 
 
 @router.put(
-    "/displayed-attributes", response_model=UpdateId, status_code=202, tags=["MeiliSearch Index"]
+    "/displayed-attributes", response_model=TaskId, status_code=202, tags=["MeiliSearch Index"]
 )
 async def update_displayed_attributes(
     displayed_attributes: DisplayedAttributesUID, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(displayed_attributes.uid)
 
@@ -336,21 +332,21 @@ async def update_displayed_attributes(
 
 
 @router.put(
-    "/attributes/distinct", response_model=UpdateId, status_code=202, tags=["MeiliSearch Index"]
+    "/attributes/distinct", response_model=TaskId, status_code=202, tags=["MeiliSearch Index"]
 )
 async def update_distinct_attribute(
     attribute_with_uid: DistinctAttributeWithUID, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(attribute_with_uid.uid)
 
         return await index.update_distinct_attribute(attribute_with_uid.attribute)
 
 
-@router.put("/", response_model=IndexInfo, tags=["MeiliSearch Index"])
+@router.put("/", response_model=TaskId, tags=["MeiliSearch Index"])
 async def update_index(
     index_update: IndexUpdate, config: MeiliSearchConfig = Depends(get_config)
-) -> IndexInfo:
+) -> TaskId:
     async with Client(config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         payload = {}
         if index_update.primary_key is not None:
@@ -359,13 +355,13 @@ async def update_index(
             f"{config.meilisearch_url}/indexes/{index_update.uid}", payload
         )
 
-        return IndexInfo(**response.json())
+        return TaskId(**response.json())
 
 
-@router.put("/ranking-rules", response_model=UpdateId, status_code=202, tags=["MeiliSearch Index"])
+@router.put("/ranking-rules", response_model=TaskId, status_code=202, tags=["MeiliSearch Index"])
 async def update_ranking_rules(
     ranking_rules: RankingRulesWithUID, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(ranking_rules.uid)
 
@@ -373,12 +369,12 @@ async def update_ranking_rules(
 
 
 @router.put(
-    "/searchable-attributes", response_model=UpdateId, status_code=202, tags=["MeiliSearch Index"]
+    "/searchable-attributes", response_model=TaskId, status_code=202, tags=["MeiliSearch Index"]
 )
 async def update_searchable_attributes(
     searchable_attributes: SearchableAttributesWithUID,
     config: MeiliSearchConfig = Depends(get_config),
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(searchable_attributes.uid)
 
@@ -386,21 +382,21 @@ async def update_searchable_attributes(
 
 
 @router.put(
-    "/sortable-attributes", response_model=UpdateId, status_code=202, tags=["MeiliSearch Index"]
+    "/sortable-attributes", response_model=TaskId, status_code=202, tags=["MeiliSearch Index"]
 )
 async def update_sortable_attributes(
     sortable_attributes: SortableAttributesWithUID, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(sortable_attributes.uid)
 
         return await index.update_sortable_attributes(sortable_attributes.sortable_attributes)
 
 
-@router.put("/stop-words", response_model=UpdateId, status_code=202, tags=["MeiliSearch Index"])
+@router.put("/stop-words", response_model=TaskId, status_code=202, tags=["MeiliSearch Index"])
 async def update_stop_words(
     stop_words: StopWordsWithUID, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(stop_words.uid)
         words = stop_words.stop_words or []
@@ -408,10 +404,10 @@ async def update_stop_words(
         return await index.update_stop_words(words)
 
 
-@router.put("/synonyms", response_model=UpdateId, status_code=202, tags=["MeiliSearch Index"])
+@router.put("/synonyms", response_model=TaskId, status_code=202, tags=["MeiliSearch Index"])
 async def update_synonyms(
     synonyms: SynonymsWithUID, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(synonyms.uid)
 

--- a/meilisearch_fastapi/routes/meilisearch_routes.py
+++ b/meilisearch_fastapi/routes/meilisearch_routes.py
@@ -2,7 +2,7 @@ from typing import List
 
 from fastapi import APIRouter, Depends
 from meilisearch_python_async import Client
-from meilisearch_python_async.models.client import ClientStats, Key
+from meilisearch_python_async.models.client import ClientStats, Key, KeyCreate, KeyUpdate
 from meilisearch_python_async.models.health import Health
 from meilisearch_python_async.models.version import Version
 
@@ -17,10 +17,36 @@ async def get_health(config: MeiliSearchConfig = Depends(get_config)) -> Health:
         return await client.health()
 
 
+@router.post("/keys", response_model=Key, tags=["MeiliSearch"])
+async def create_key(key: KeyCreate, config: MeiliSearchConfig = Depends(get_config)) -> Key:
+    async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
+        return await client.create_key(key)
+
+
+@router.delete("/keys/{key}", status_code=204, tags=["MeiliSearch"])
+async def delete_key(key: str, config: MeiliSearchConfig = Depends(get_config)) -> int:
+    async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
+        return await client.delete_key(key)
+
+
 @router.get("/keys", response_model=List[Key], tags=["MeiliSearch"])
 async def get_keys(config: MeiliSearchConfig = Depends(get_config)) -> List[Key]:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         return await client.get_keys()
+
+
+@router.get("/keys/{key}", response_model=Key, tags=["MeiliSearch"])
+async def get_key(key: str, config: MeiliSearchConfig = Depends(get_config)) -> Key:
+    async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
+        return await client.get_key(key)
+
+
+@router.patch("/keys/{key}", response_model=Key, tags=["MeiliSearch"])
+async def update_key(
+    key: str, update_key: KeyUpdate, config: MeiliSearchConfig = Depends(get_config)
+) -> Key:
+    async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
+        return await client.update_key(update_key)
 
 
 @router.get("/stats", response_model=ClientStats, tags=["MeiliSearch"])

--- a/meilisearch_fastapi/routes/meilisearch_routes.py
+++ b/meilisearch_fastapi/routes/meilisearch_routes.py
@@ -1,8 +1,8 @@
-from __future__ import annotations
+from typing import List
 
 from fastapi import APIRouter, Depends
 from meilisearch_python_async import Client
-from meilisearch_python_async.models.client import ClientStats, Keys
+from meilisearch_python_async.models.client import ClientStats, Key
 from meilisearch_python_async.models.health import Health
 from meilisearch_python_async.models.version import Version
 
@@ -17,8 +17,8 @@ async def get_health(config: MeiliSearchConfig = Depends(get_config)) -> Health:
         return await client.health()
 
 
-@router.get("/keys", response_model=Keys, tags=["MeiliSearch"])
-async def get_keys(config: MeiliSearchConfig = Depends(get_config)) -> Keys:
+@router.get("/keys", response_model=List[Key], tags=["MeiliSearch"])
+async def get_keys(config: MeiliSearchConfig = Depends(get_config)) -> List[Key]:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         return await client.get_keys()
 

--- a/meilisearch_fastapi/routes/search_routes.py
+++ b/meilisearch_fastapi/routes/search_routes.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from fastapi import APIRouter, Depends
 from meilisearch_python_async import Client
 from meilisearch_python_async.models.search import SearchResults

--- a/meilisearch_fastapi/routes/settings_routes.py
+++ b/meilisearch_fastapi/routes/settings_routes.py
@@ -1,9 +1,7 @@
-from __future__ import annotations
-
 from fastapi import APIRouter, Depends
 from meilisearch_python_async import Client
 from meilisearch_python_async.models.settings import MeiliSearchSettings
-from meilisearch_python_async.models.update import UpdateId
+from meilisearch_python_async.models.task import TaskId
 
 from meilisearch_fastapi._config import MeiliSearchConfig, get_config
 from meilisearch_fastapi.models.settings import MeiliSearchIndexSettings
@@ -21,18 +19,18 @@ async def get_settings(
         return await index.get_settings()
 
 
-@router.delete("/{uid}", response_model=UpdateId, tags=["MeiliSearch Settings"])
-async def delete_settings(uid: str, config: MeiliSearchConfig = Depends(get_config)) -> UpdateId:
+@router.delete("/{uid}", response_model=TaskId, tags=["MeiliSearch Settings"])
+async def delete_settings(uid: str, config: MeiliSearchConfig = Depends(get_config)) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
 
         return await index.reset_settings()
 
 
-@router.post("/", response_model=UpdateId, tags=["MeiliSearch Settings"])
+@router.post("/", response_model=TaskId, tags=["MeiliSearch Settings"])
 async def update_settings(
     update_settings: MeiliSearchIndexSettings, config: MeiliSearchConfig = Depends(get_config)
-) -> UpdateId:
+) -> TaskId:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(update_settings.uid)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,7 +8,7 @@ python-versions = ">=3.6,<4.0"
 
 [[package]]
 name = "anyio"
-version = "3.4.0"
+version = "3.5.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 category = "main"
 optional = false
@@ -20,7 +20,7 @@ sniffio = ">=1.1"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
-doc = ["sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
+doc = ["packaging", "sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
 test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
 trio = ["trio (>=0.16)"]
 
@@ -48,32 +48,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.2.0"
+version = "21.4.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
-
-[[package]]
-name = "backports.entry-points-selectable"
-version = "1.1.1"
-description = "Compatibility shim providing selectable entry points for older implementations"
-category = "dev"
-optional = false
-python-versions = ">=2.7"
-
-[package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-checkdocs (>=2.4)", "pytest-enabler (>=1.0.1)"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "black"
@@ -131,7 +116,7 @@ python-versions = ">=3.6.1"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.9"
+version = "2.0.10"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -202,11 +187,11 @@ test = ["pytest (>=6.2.4,<7.0.0)", "pytest-cov (>=2.12.0,<4.0.0)", "mypy (==0.91
 
 [[package]]
 name = "filelock"
-version = "3.4.0"
+version = "3.4.2"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
@@ -236,7 +221,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "httpcore"
-version = "0.14.3"
+version = "0.14.4"
 description = "A minimal low-level HTTP client."
 category = "main"
 optional = false
@@ -273,7 +258,7 @@ http2 = ["h2 (>=3,<5)"]
 
 [[package]]
 name = "identify"
-version = "2.4.0"
+version = "2.4.3"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -405,11 +390,11 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
 name = "platformdirs"
-version = "2.4.0"
+version = "2.4.1"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
@@ -687,14 +672,13 @@ standard = ["httptools (>=0.2.0,<0.4.0)", "watchgod (>=0.6)", "python-dotenv (>=
 
 [[package]]
 name = "virtualenv"
-version = "20.10.0"
+version = "20.13.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [package.dependencies]
-"backports.entry-points-selectable" = ">=1.0.4"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.2,<4"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
@@ -707,20 +691,20 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 
 [[package]]
 name = "zipp"
-version = "3.6.0"
+version = "3.7.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "4c9b8e2986cd0c97a01621be152b39573829e86f6af208453b57d6669d3efa41"
+content-hash = "cb1653f9e425a1038abd392fa883e004385880edcff9e43377af506aa1f44bde"
 
 [metadata.files]
 aiofiles = [
@@ -728,8 +712,8 @@ aiofiles = [
     {file = "aiofiles-0.8.0.tar.gz", hash = "sha256:8334f23235248a3b2e83b2c3a78a22674f39969b96397126cc93664d9a901e59"},
 ]
 anyio = [
-    {file = "anyio-3.4.0-py3-none-any.whl", hash = "sha256:2855a9423524abcdd652d942f8932fda1735210f77a6b392eafd9ff34d3fe020"},
-    {file = "anyio-3.4.0.tar.gz", hash = "sha256:24adc69309fb5779bc1e06158e143e0b6d2c56b302a3ac3de3083c705a6ed39d"},
+    {file = "anyio-3.5.0-py3-none-any.whl", hash = "sha256:b5fa16c5ff93fa1046f2eeb5bbff2dad4d3514d6cda61d02816dba34fa8c3c2e"},
+    {file = "anyio-3.5.0.tar.gz", hash = "sha256:a0aeffe2fb1fdf374a8e4b471444f0f3ac4fb9f5a5b542b48824475e0042a5a6"},
 ]
 asgiref = [
     {file = "asgiref-3.4.1-py3-none-any.whl", hash = "sha256:ffc141aa908e6f175673e7b1b3b7af4fdb0ecb738fc5c8b88f69f055c2415214"},
@@ -740,12 +724,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
-    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
-]
-"backports.entry-points-selectable" = [
-    {file = "backports.entry_points_selectable-1.1.1-py2.py3-none-any.whl", hash = "sha256:7fceed9532a7aa2bd888654a7314f864a3c16a4e710b34a58cfc0f08114c663b"},
-    {file = "backports.entry_points_selectable-1.1.1.tar.gz", hash = "sha256:914b21a479fde881635f7af5adc7f6e38d6b274be32269070c53b698c60d5386"},
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 black = [
     {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
@@ -764,8 +744,8 @@ cfgv = [
     {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.9.tar.gz", hash = "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"},
-    {file = "charset_normalizer-2.0.9-py3-none-any.whl", hash = "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721"},
+    {file = "charset-normalizer-2.0.10.tar.gz", hash = "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd"},
+    {file = "charset_normalizer-2.0.10-py3-none-any.whl", hash = "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"},
 ]
 click = [
     {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
@@ -833,8 +813,8 @@ fastapi = [
     {file = "fastapi-0.71.0.tar.gz", hash = "sha256:2b5ac0ae89c80b40d1dd4b2ea0bb1f78d7c4affd3644d080bf050f084759fff2"},
 ]
 filelock = [
-    {file = "filelock-3.4.0-py3-none-any.whl", hash = "sha256:2e139a228bcf56dd8b2274a65174d005c4a6b68540ee0bdbb92c76f43f29f7e8"},
-    {file = "filelock-3.4.0.tar.gz", hash = "sha256:93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4"},
+    {file = "filelock-3.4.2-py3-none-any.whl", hash = "sha256:cf0fc6a2f8d26bd900f19bf33915ca70ba4dd8c56903eeb14e1e7a2fd7590146"},
+    {file = "filelock-3.4.2.tar.gz", hash = "sha256:38b4f4c989f9d06d44524df1b24bd19e167d851f19b50bf3e3559952dddc5b80"},
 ]
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
@@ -845,16 +825,16 @@ h11 = [
     {file = "h11-0.12.0.tar.gz", hash = "sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042"},
 ]
 httpcore = [
-    {file = "httpcore-0.14.3-py3-none-any.whl", hash = "sha256:9a98d2416b78976fc5396ff1f6b26ae9885efbb3105d24eed490f20ab4c95ec1"},
-    {file = "httpcore-0.14.3.tar.gz", hash = "sha256:d10162a63265a0228d5807964bd964478cbdb5178f9a2eedfebb2faba27eef5d"},
+    {file = "httpcore-0.14.4-py3-none-any.whl", hash = "sha256:9410fe352bea732311f2b2bee0555c8cc5e62b9a73b9d3272fe125a2aa6eb28e"},
+    {file = "httpcore-0.14.4.tar.gz", hash = "sha256:d4305811f604d3c2e22869147392f134796976ff946c96a8cfba87f4e0171d83"},
 ]
 httpx = [
     {file = "httpx-0.21.3-py3-none-any.whl", hash = "sha256:df9a0fd43fa79dbab411d83eb1ea6f7a525c96ad92e60c2d7f40388971b25777"},
     {file = "httpx-0.21.3.tar.gz", hash = "sha256:7a3eb67ef0b8abbd6d9402248ef2f84a76080fa1c839f8662e6eb385640e445a"},
 ]
 identify = [
-    {file = "identify-2.4.0-py2.py3-none-any.whl", hash = "sha256:eba31ca80258de6bb51453084bff4a923187cd2193b9c13710f2516ab30732cc"},
-    {file = "identify-2.4.0.tar.gz", hash = "sha256:a33ae873287e81651c7800ca309dc1f84679b763c9c8b30680e16fbfa82f0107"},
+    {file = "identify-2.4.3-py2.py3-none-any.whl", hash = "sha256:ac9c919c8ac5b90d03f8e1bce6dedcbd8a3b2a59c46737c04ed852e2d307af29"},
+    {file = "identify-2.4.3.tar.gz", hash = "sha256:8d80d877441073e7222ff272da45ca5ca1d901412790544b446e7d363ad5e9f0"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -919,8 +899,8 @@ pathspec = [
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
-    {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
+    {file = "platformdirs-2.4.1-py3-none-any.whl", hash = "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca"},
+    {file = "platformdirs-2.4.1.tar.gz", hash = "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -1092,10 +1072,10 @@ uvicorn = [
     {file = "uvicorn-0.16.0.tar.gz", hash = "sha256:eacb66afa65e0648fcbce5e746b135d09722231ffffc61883d4fac2b62fbea8d"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.10.0-py2.py3-none-any.whl", hash = "sha256:4b02e52a624336eece99c96e3ab7111f469c24ba226a53ec474e8e787b365814"},
-    {file = "virtualenv-20.10.0.tar.gz", hash = "sha256:576d05b46eace16a9c348085f7d0dc8ef28713a2cabaa1cf0aea41e8f12c9218"},
+    {file = "virtualenv-20.13.0-py2.py3-none-any.whl", hash = "sha256:339f16c4a86b44240ba7223d0f93a7887c3ca04b5f9c8129da7958447d079b09"},
+    {file = "virtualenv-20.13.0.tar.gz", hash = "sha256:d8458cf8d59d0ea495ad9b34c2599487f8a7772d796f9910858376d1600dd2dd"},
 ]
 zipp = [
-    {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},
-    {file = "zipp-3.6.0.tar.gz", hash = "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832"},
+    {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
+    {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -342,20 +342,13 @@ version = "0.21.0"
 description = "A Python async client for the MeiliSearch API"
 category = "main"
 optional = false
-python-versions = "^3.7"
-develop = false
+python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
 aiofiles = ">=0.7,<0.9"
-camel-converter = "^1.0.0"
+camel-converter = ">=1.0.0,<2.0.0"
 httpx = ">=0.17,<0.22"
-pydantic = "^1.8"
-
-[package.source]
-type = "git"
-url = "https://github.com/sanders41/meilisearch-python-async.git"
-reference = "meilisearch-v0.25.0"
-resolved_reference = "28a7ef84e2828363518f742303d69052d245ff72"
+pydantic = ">=1.8,<2.0"
 
 [[package]]
 name = "mypy"
@@ -883,7 +876,10 @@ mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
-meilisearch-python-async = []
+meilisearch-python-async = [
+    {file = "meilisearch-python-async-0.21.0.tar.gz", hash = "sha256:cb99f868ec07aacf38acab7ca5a61edc56e5a04038ce7ada03d9375fbdd32138"},
+    {file = "meilisearch_python_async-0.21.0-py3-none-any.whl", hash = "sha256:dcd22da73882e3abc70c4ea86709e0b2d3f86262b8c09b272ab3d1c80687a1a1"},
+]
 mypy = [
     {file = "mypy-0.931-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3c5b42d0815e15518b1f0990cff7a705805961613e701db60387e6fb663fe78a"},
     {file = "mypy-0.931-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c89702cac5b302f0c5d33b172d2b55b5df2bede3344a2fbed99ff96bddb2cf00"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "aiofiles"
-version = "0.7.0"
+version = "0.8.0"
 description = "File support for asyncio."
 category = "main"
 optional = false
@@ -8,7 +8,7 @@ python-versions = ">=3.6,<4.0"
 
 [[package]]
 name = "anyio"
-version = "3.3.4"
+version = "3.4.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 category = "main"
 optional = false
@@ -21,7 +21,7 @@ typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 doc = ["sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
-test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
+test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
 trio = ["trio (>=0.16)"]
 
 [[package]]
@@ -62,7 +62,7 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "backports.entry-points-selectable"
-version = "1.1.0"
+version = "1.1.1"
 description = "Compatibility shim providing selectable entry points for older implementations"
 category = "dev"
 optional = false
@@ -73,7 +73,7 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-checkdocs (>=2.4)", "pytest-enabler (>=1.0.1)"]
+testing = ["pytest", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-checkdocs (>=2.4)", "pytest-enabler (>=1.0.1)"]
 
 [[package]]
 name = "black"
@@ -131,7 +131,7 @@ python-versions = ">=3.6.1"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.7"
+version = "2.0.9"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -176,7 +176,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "distlib"
-version = "0.3.3"
+version = "0.3.4"
 description = "Distribution utilities"
 category = "dev"
 optional = false
@@ -202,7 +202,7 @@ test = ["pytest (>=6.2.4,<7.0.0)", "pytest-cov (>=2.12.0,<4.0.0)", "mypy (==0.91
 
 [[package]]
 name = "filelock"
-version = "3.3.1"
+version = "3.4.0"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
@@ -236,7 +236,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "httpcore"
-version = "0.14.2"
+version = "0.14.3"
 description = "A minimal low-level HTTP client."
 category = "main"
 optional = false
@@ -273,14 +273,14 @@ http2 = ["h2 (>=3,<5)"]
 
 [[package]]
 name = "identify"
-version = "2.3.1"
+version = "2.4.0"
 description = "File identification library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.6.1"
 
 [package.extras]
-license = ["editdistance-s"]
+license = ["ukkonen"]
 
 [[package]]
 name = "idna"
@@ -338,17 +338,24 @@ python-versions = "*"
 
 [[package]]
 name = "meilisearch-python-async"
-version = "0.20.1"
+version = "0.21.0"
 description = "A Python async client for the MeiliSearch API"
 category = "main"
 optional = false
-python-versions = ">=3.7,<4.0"
+python-versions = "^3.7"
+develop = false
 
 [package.dependencies]
-aiofiles = ">=0.7.0,<0.8.0"
-camel-converter = ">=1.0.0,<2.0.0"
+aiofiles = ">=0.7,<0.9"
+camel-converter = "^1.0.0"
 httpx = ">=0.17,<0.22"
-pydantic = ">=1.8,<2.0"
+pydantic = "^1.8"
+
+[package.source]
+type = "git"
+url = "https://github.com/sanders41/meilisearch-python-async.git"
+reference = "meilisearch-v0.25.0"
+resolved_reference = "28a7ef84e2828363518f742303d69052d245ff72"
 
 [[package]]
 name = "mypy"
@@ -386,14 +393,14 @@ python-versions = "*"
 
 [[package]]
 name = "packaging"
-version = "21.0"
+version = "21.3"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyparsing = ">=2.0.2"
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pathspec"
@@ -449,11 +456,11 @@ virtualenv = ">=20.0.8"
 
 [[package]]
 name = "py"
-version = "1.10.0"
+version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycodestyle"
@@ -489,7 +496,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyparsing"
-version = "3.0.1"
+version = "3.0.6"
 description = "Python parsing module"
 category = "dev"
 optional = false
@@ -551,7 +558,7 @@ testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtuale
 
 [[package]]
 name = "python-dotenv"
-version = "0.19.1"
+version = "0.19.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 category = "main"
 optional = false
@@ -623,7 +630,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
-version = "1.2.2"
+version = "1.2.3"
 description = "A lil' TOML parser"
 category = "dev"
 optional = false
@@ -654,19 +661,19 @@ testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytes
 
 [[package]]
 name = "typed-ast"
-version = "1.4.3"
+version = "1.5.1"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "typing-extensions"
-version = "3.10.0.2"
-description = "Backported and Experimental Type Hints for Python 3.5+"
+version = "4.0.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "uvicorn"
@@ -687,7 +694,7 @@ standard = ["httptools (>=0.2.0,<0.4.0)", "watchgod (>=0.6)", "python-dotenv (>=
 
 [[package]]
 name = "virtualenv"
-version = "20.9.0"
+version = "20.10.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -702,7 +709,7 @@ platformdirs = ">=2,<3"
 six = ">=1.9.0,<2"
 
 [package.extras]
-docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
+docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
 testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
 
 [[package]]
@@ -724,12 +731,12 @@ content-hash = "4c9b8e2986cd0c97a01621be152b39573829e86f6af208453b57d6669d3efa41
 
 [metadata.files]
 aiofiles = [
-    {file = "aiofiles-0.7.0-py3-none-any.whl", hash = "sha256:c67a6823b5f23fcab0a2595a289cec7d8c863ffcb4322fb8cd6b90400aedfdbc"},
-    {file = "aiofiles-0.7.0.tar.gz", hash = "sha256:a1c4fc9b2ff81568c83e21392a82f344ea9d23da906e4f6a52662764545e19d4"},
+    {file = "aiofiles-0.8.0-py3-none-any.whl", hash = "sha256:7a973fc22b29e9962d0897805ace5856e6a566ab1f0c8e5c91ff6c866519c937"},
+    {file = "aiofiles-0.8.0.tar.gz", hash = "sha256:8334f23235248a3b2e83b2c3a78a22674f39969b96397126cc93664d9a901e59"},
 ]
 anyio = [
-    {file = "anyio-3.3.4-py3-none-any.whl", hash = "sha256:4fd09a25ab7fa01d34512b7249e366cd10358cdafc95022c7ff8c8f8a5026d66"},
-    {file = "anyio-3.3.4.tar.gz", hash = "sha256:67da67b5b21f96b9d3d65daa6ea99f5d5282cb09f50eb4456f8fb51dffefc3ff"},
+    {file = "anyio-3.4.0-py3-none-any.whl", hash = "sha256:2855a9423524abcdd652d942f8932fda1735210f77a6b392eafd9ff34d3fe020"},
+    {file = "anyio-3.4.0.tar.gz", hash = "sha256:24adc69309fb5779bc1e06158e143e0b6d2c56b302a3ac3de3083c705a6ed39d"},
 ]
 asgiref = [
     {file = "asgiref-3.4.1-py3-none-any.whl", hash = "sha256:ffc141aa908e6f175673e7b1b3b7af4fdb0ecb738fc5c8b88f69f055c2415214"},
@@ -744,8 +751,8 @@ attrs = [
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
 "backports.entry-points-selectable" = [
-    {file = "backports.entry_points_selectable-1.1.0-py2.py3-none-any.whl", hash = "sha256:a6d9a871cde5e15b4c4a53e3d43ba890cc6861ec1332c9c2428c92f977192acc"},
-    {file = "backports.entry_points_selectable-1.1.0.tar.gz", hash = "sha256:988468260ec1c196dab6ae1149260e2f5472c9110334e5d51adcb77867361f6a"},
+    {file = "backports.entry_points_selectable-1.1.1-py2.py3-none-any.whl", hash = "sha256:7fceed9532a7aa2bd888654a7314f864a3c16a4e710b34a58cfc0f08114c663b"},
+    {file = "backports.entry_points_selectable-1.1.1.tar.gz", hash = "sha256:914b21a479fde881635f7af5adc7f6e38d6b274be32269070c53b698c60d5386"},
 ]
 black = [
     {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
@@ -764,8 +771,8 @@ cfgv = [
     {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.7.tar.gz", hash = "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0"},
-    {file = "charset_normalizer-2.0.7-py3-none-any.whl", hash = "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"},
+    {file = "charset-normalizer-2.0.9.tar.gz", hash = "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"},
+    {file = "charset_normalizer-2.0.9-py3-none-any.whl", hash = "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721"},
 ]
 click = [
     {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
@@ -825,16 +832,16 @@ coverage = [
     {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
 ]
 distlib = [
-    {file = "distlib-0.3.3-py2.py3-none-any.whl", hash = "sha256:c8b54e8454e5bf6237cc84c20e8264c3e991e824ef27e8f1e81049867d861e31"},
-    {file = "distlib-0.3.3.zip", hash = "sha256:d982d0751ff6eaaab5e2ec8e691d949ee80eddf01a62eaa96ddb11531fe16b05"},
+    {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
+    {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
 ]
 fastapi = [
     {file = "fastapi-0.71.0-py3-none-any.whl", hash = "sha256:a78eca6b084de9667f2d5f37e2ae297270e5a119cd01c2f04815795da92fc87f"},
     {file = "fastapi-0.71.0.tar.gz", hash = "sha256:2b5ac0ae89c80b40d1dd4b2ea0bb1f78d7c4affd3644d080bf050f084759fff2"},
 ]
 filelock = [
-    {file = "filelock-3.3.1-py3-none-any.whl", hash = "sha256:2b5eb3589e7fdda14599e7eb1a50e09b4cc14f34ed98b8ba56d33bfaafcbef2f"},
-    {file = "filelock-3.3.1.tar.gz", hash = "sha256:34a9f35f95c441e7b38209775d6e0337f9a3759f3565f6c5798f19618527c76f"},
+    {file = "filelock-3.4.0-py3-none-any.whl", hash = "sha256:2e139a228bcf56dd8b2274a65174d005c4a6b68540ee0bdbb92c76f43f29f7e8"},
+    {file = "filelock-3.4.0.tar.gz", hash = "sha256:93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4"},
 ]
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
@@ -845,16 +852,16 @@ h11 = [
     {file = "h11-0.12.0.tar.gz", hash = "sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042"},
 ]
 httpcore = [
-    {file = "httpcore-0.14.2-py3-none-any.whl", hash = "sha256:47d7c8f755719d4a57be0b6e022897e9e963bf9ce4b15b9cc006a38a1cfa2932"},
-    {file = "httpcore-0.14.2.tar.gz", hash = "sha256:ff8f8b9434ec4823f95a30596fbe78039913e706d3e598b0b8955b1e1828e093"},
+    {file = "httpcore-0.14.3-py3-none-any.whl", hash = "sha256:9a98d2416b78976fc5396ff1f6b26ae9885efbb3105d24eed490f20ab4c95ec1"},
+    {file = "httpcore-0.14.3.tar.gz", hash = "sha256:d10162a63265a0228d5807964bd964478cbdb5178f9a2eedfebb2faba27eef5d"},
 ]
 httpx = [
     {file = "httpx-0.21.3-py3-none-any.whl", hash = "sha256:df9a0fd43fa79dbab411d83eb1ea6f7a525c96ad92e60c2d7f40388971b25777"},
     {file = "httpx-0.21.3.tar.gz", hash = "sha256:7a3eb67ef0b8abbd6d9402248ef2f84a76080fa1c839f8662e6eb385640e445a"},
 ]
 identify = [
-    {file = "identify-2.3.1-py2.py3-none-any.whl", hash = "sha256:5a5000bd3293950d992843c0ef3d82b90a582de2161557bda7f493c8c8864f26"},
-    {file = "identify-2.3.1.tar.gz", hash = "sha256:8a92c56893e9a4ce951f09a50489986615e3eba7b4c60610e0b25f93ca4487ba"},
+    {file = "identify-2.4.0-py2.py3-none-any.whl", hash = "sha256:eba31ca80258de6bb51453084bff4a923187cd2193b9c13710f2516ab30732cc"},
+    {file = "identify-2.4.0.tar.gz", hash = "sha256:a33ae873287e81651c7800ca309dc1f84679b763c9c8b30680e16fbfa82f0107"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -876,10 +883,7 @@ mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
-meilisearch-python-async = [
-    {file = "meilisearch-python-async-0.20.1.tar.gz", hash = "sha256:cb5f86a74a2fb8dc531d9facec56e5681d38ca5344d8ce26623e2fab1c744e89"},
-    {file = "meilisearch_python_async-0.20.1-py3-none-any.whl", hash = "sha256:f829f99ed7319c67ce6081a25814365ddf14b133fefa254386c592f2b6e9ad16"},
-]
+meilisearch-python-async = []
 mypy = [
     {file = "mypy-0.931-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3c5b42d0815e15518b1f0990cff7a705805961613e701db60387e6fb663fe78a"},
     {file = "mypy-0.931-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c89702cac5b302f0c5d33b172d2b55b5df2bede3344a2fbed99ff96bddb2cf00"},
@@ -911,8 +915,8 @@ nodeenv = [
     {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
 ]
 packaging = [
-    {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
-    {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
@@ -931,8 +935,8 @@ pre-commit = [
     {file = "pre_commit-2.16.0.tar.gz", hash = "sha256:fe9897cac830aa7164dbd02a4e7b90cae49630451ce88464bca73db486ba9f65"},
 ]
 py = [
-    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
-    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
@@ -980,8 +984,8 @@ pyflakes = [
     {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
 pyparsing = [
-    {file = "pyparsing-3.0.1-py3-none-any.whl", hash = "sha256:fd93fc45c47893c300bd98f5dd1b41c0e783eaeb727e7cea210dcc09d64ce7c3"},
-    {file = "pyparsing-3.0.1.tar.gz", hash = "sha256:84196357aa3566d64ad123d7a3c67b0e597a115c4934b097580e5ce220b91531"},
+    {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
+    {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
 ]
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
@@ -996,8 +1000,8 @@ pytest-cov = [
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
 ]
 python-dotenv = [
-    {file = "python-dotenv-0.19.1.tar.gz", hash = "sha256:14f8185cc8d494662683e6914addcb7e95374771e707601dfc70166946b4c4b8"},
-    {file = "python_dotenv-0.19.1-py2.py3-none-any.whl", hash = "sha256:bbd3da593fc49c249397cbfbcc449cf36cb02e75afc8157fcc6a81df6fb7750a"},
+    {file = "python-dotenv-0.19.2.tar.gz", hash = "sha256:a5de49a31e953b45ff2d2fd434bbc2670e8db5273606c1e737cc6b93eff3655f"},
+    {file = "python_dotenv-0.19.2-py2.py3-none-any.whl", hash = "sha256:32b2bdc1873fd3a3c346da1c6db83d0053c3c62f28f1f38516070c4c8971b1d3"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -1055,57 +1059,45 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
-    {file = "tomli-1.2.2-py3-none-any.whl", hash = "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"},
-    {file = "tomli-1.2.2.tar.gz", hash = "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee"},
+    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
+    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
 tox = [
     {file = "tox-3.24.5-py2.py3-none-any.whl", hash = "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"},
     {file = "tox-3.24.5.tar.gz", hash = "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993"},
 ]
 typed-ast = [
-    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
-    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075"},
-    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528"},
-    {file = "typed_ast-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428"},
-    {file = "typed_ast-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805"},
-    {file = "typed_ast-1.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a"},
-    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff"},
-    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41"},
-    {file = "typed_ast-1.4.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39"},
-    {file = "typed_ast-1.4.3-cp38-cp38-win32.whl", hash = "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927"},
-    {file = "typed_ast-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40"},
-    {file = "typed_ast-1.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3"},
-    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4"},
-    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0"},
-    {file = "typed_ast-1.4.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3"},
-    {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
-    {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
-    {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
+    {file = "typed_ast-1.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5d8314c92414ce7481eee7ad42b353943679cf6f30237b5ecbf7d835519e1212"},
+    {file = "typed_ast-1.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b53ae5de5500529c76225d18eeb060efbcec90ad5e030713fe8dab0fb4531631"},
+    {file = "typed_ast-1.5.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:24058827d8f5d633f97223f5148a7d22628099a3d2efe06654ce872f46f07cdb"},
+    {file = "typed_ast-1.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:a6d495c1ef572519a7bac9534dbf6d94c40e5b6a608ef41136133377bba4aa08"},
+    {file = "typed_ast-1.5.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:de4ecae89c7d8b56169473e08f6bfd2df7f95015591f43126e4ea7865928677e"},
+    {file = "typed_ast-1.5.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:256115a5bc7ea9e665c6314ed6671ee2c08ca380f9d5f130bd4d2c1f5848d695"},
+    {file = "typed_ast-1.5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:7c42707ab981b6cf4b73490c16e9d17fcd5227039720ca14abe415d39a173a30"},
+    {file = "typed_ast-1.5.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:71dcda943a471d826ea930dd449ac7e76db7be778fcd722deb63642bab32ea3f"},
+    {file = "typed_ast-1.5.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4f30a2bcd8e68adbb791ce1567fdb897357506f7ea6716f6bbdd3053ac4d9471"},
+    {file = "typed_ast-1.5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:ca9e8300d8ba0b66d140820cf463438c8e7b4cdc6fd710c059bfcfb1531d03fb"},
+    {file = "typed_ast-1.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9caaf2b440efb39ecbc45e2fabde809cbe56272719131a6318fd9bf08b58e2cb"},
+    {file = "typed_ast-1.5.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c9bcad65d66d594bffab8575f39420fe0ee96f66e23c4d927ebb4e24354ec1af"},
+    {file = "typed_ast-1.5.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:591bc04e507595887160ed7aa8d6785867fb86c5793911be79ccede61ae96f4d"},
+    {file = "typed_ast-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:a80d84f535642420dd17e16ae25bb46c7f4c16ee231105e7f3eb43976a89670a"},
+    {file = "typed_ast-1.5.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:38cf5c642fa808300bae1281460d4f9b7617cf864d4e383054a5ef336e344d32"},
+    {file = "typed_ast-1.5.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5b6ab14c56bc9c7e3c30228a0a0b54b915b1579613f6e463ba6f4eb1382e7fd4"},
+    {file = "typed_ast-1.5.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a2b8d7007f6280e36fa42652df47087ac7b0a7d7f09f9468f07792ba646aac2d"},
+    {file = "typed_ast-1.5.1-cp39-cp39-win_amd64.whl", hash = "sha256:b6d17f37f6edd879141e64a5db17b67488cfeffeedad8c5cec0392305e9bc775"},
+    {file = "typed_ast-1.5.1.tar.gz", hash = "sha256:484137cab8ecf47e137260daa20bafbba5f4e3ec7fda1c1e69ab299b75fa81c5"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
-    {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
-    {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
+    {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
+    {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
 ]
 uvicorn = [
     {file = "uvicorn-0.16.0-py3-none-any.whl", hash = "sha256:d8c839231f270adaa6d338d525e2652a0b4a5f4c2430b5c4ef6ae4d11776b0d2"},
     {file = "uvicorn-0.16.0.tar.gz", hash = "sha256:eacb66afa65e0648fcbce5e746b135d09722231ffffc61883d4fac2b62fbea8d"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.9.0-py2.py3-none-any.whl", hash = "sha256:1d145deec2da86b29026be49c775cc5a9aab434f85f7efef98307fb3965165de"},
-    {file = "virtualenv-20.9.0.tar.gz", hash = "sha256:bb55ace18de14593947354e5e6cd1be75fb32c3329651da62e92bf5d0aab7213"},
+    {file = "virtualenv-20.10.0-py2.py3-none-any.whl", hash = "sha256:4b02e52a624336eece99c96e3ab7111f469c24ba226a53ec474e8e787b365814"},
+    {file = "virtualenv-20.10.0.tar.gz", hash = "sha256:576d05b46eace16a9c348085f7d0dc8ef28713a2cabaa1cf0aea41e8f12c9218"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ include = ["meilisearch_fastapi/py.typed"]
 python = "^3.7"
 fastapi = ">=0.65.1,<0.72.0"
 pydantic = {version = "^1.8.2", extras = ["dotenv"]}
-# meilisearch-python-async = "^0.20.0"
-meilisearch-python-async = { git = "https://github.com/sanders41/meilisearch-python-async.git", branch = "meilisearch-v0.25.0" }
+meilisearch-python-async = "^0.21.0"
 
 [tool.poetry.dev-dependencies]
 black = "^21.12b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ include = ["meilisearch_fastapi/py.typed"]
 python = "^3.7"
 fastapi = ">=0.65.1,<0.72.0"
 pydantic = {version = "^1.8.2", extras = ["dotenv"]}
-meilisearch-python-async = "^0.20.0"
+# meilisearch-python-async = "^0.20.0"
+meilisearch-python-async = { git = "https://github.com/sanders41/meilisearch-python-async.git", branch = "meilisearch-v0.25.0" }
 
 [tool.poetry.dev-dependencies]
 black = "^21.12b0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi import APIRouter, FastAPI
 from httpx import AsyncClient
 from meilisearch_python_async import Client
+from meilisearch_python_async.task import wait_for_task
 
 from meilisearch_fastapi._config import get_config
 from meilisearch_fastapi.routes import (
@@ -77,6 +78,13 @@ async def test_client():
         yield ac
 
 
+@pytest.fixture
+@pytest.mark.asyncio
+async def raw_client():
+    async with Client(MEILISEARCH_URL, MASTER_KEY) as client:
+        yield client
+
+
 @pytest.mark.asyncio
 @pytest.fixture(autouse=True)
 async def clear_indexes(test_client):
@@ -89,7 +97,8 @@ async def clear_indexes(test_client):
         indexes = await client.get_indexes()
         if indexes:
             for index in indexes:
-                await client.index(index.uid).delete()
+                response = await client.index(index.uid).delete()
+                await wait_for_task(client.http_client, response.uid)
 
 
 @pytest.fixture(autouse=True)
@@ -139,7 +148,7 @@ def small_movies():
 async def index_with_documents(empty_index, small_movies):
     uid, index = empty_index
     response = await index.add_documents(small_movies)
-    await index.wait_for_pending_update(response.update_id)
+    await wait_for_task(index.http_client, response.uid)
 
     yield uid, index
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,13 +81,13 @@ async def test_client():
 @pytest.fixture
 @pytest.mark.asyncio
 async def raw_client():
-    async with Client(MEILISEARCH_URL, MASTER_KEY) as client:
+    async with Client(f"http://{MEILISEARCH_URL}", MASTER_KEY) as client:
         yield client
 
 
 @pytest.mark.asyncio
 @pytest.fixture(autouse=True)
-async def clear_indexes(test_client):
+async def clear_indexes():
     """Auto-clears the indexes after each test function run.
     Makes all the test functions independent.
     """

--- a/tests/test_index_routes.py
+++ b/tests/test_index_routes.py
@@ -1,5 +1,6 @@
 import pytest
 from meilisearch_python_async.models.settings import MeiliSearchSettings
+from meilisearch_python_async.task import wait_for_task
 
 
 @pytest.fixture
@@ -162,10 +163,12 @@ async def test_delete_if_exists(test_client, test_uid):
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("indexes_sample")
-async def test_update_index(test_client, index_uid):
+async def test_update_index(test_client, index_uid, raw_client):
     primay_key = "objectID"
     update_data = {"uid": index_uid, "primaryKey": primay_key}
-    response = await test_client.put("/indexes", json=update_data)
+    update = await test_client.put("/indexes", json=update_data)
+    await wait_for_task(raw_client.http_client, update.json()["uid"])
+    response = await test_client.get(f"/indexes/{index_uid}")
     response_primary_key = response.json()["primaryKey"]
 
     assert response_primary_key == primay_key
@@ -176,7 +179,7 @@ async def test_get_stats(test_client, empty_index, small_movies):
     uid, index = empty_index
     data = {"uid": uid, "documents": small_movies}
     update = await test_client.put("/documents", json=data)
-    await index.wait_for_pending_update(update.json()["updateId"])
+    await wait_for_task(index.http_client, update.json()["uid"])
     response = await test_client.get(f"/indexes/stats/{uid}")
 
     assert response.json()["numberOfDocuments"] == 30
@@ -195,7 +198,7 @@ async def test_update_ranking_rules(test_client, empty_index, new_ranking_rules)
     uid, index = empty_index
     data = {"uid": uid, "rankingRules": new_ranking_rules}
     response = await test_client.put("/indexes/ranking-rules", json=data)
-    await index.wait_for_pending_update(response.json()["updateId"])
+    await wait_for_task(index.http_client, response.json()["uid"])
     response = await test_client.get(f"/indexes/ranking-rules/{uid}")
     ranking_rules = response.json()["rankingRules"]
     assert ranking_rules == new_ranking_rules
@@ -208,12 +211,12 @@ async def test_reset_ranking_rules(
     uid, index = empty_index
     data = {"uid": uid, "rankingRules": new_ranking_rules}
     response = await test_client.put("/indexes/ranking-rules", json=data)
-    await index.wait_for_pending_update(response.json()["updateId"])
+    await wait_for_task(index.http_client, response.json()["uid"])
     response = await test_client.get(f"/indexes/ranking-rules/{uid}")
     ranking_rules = response.json()["rankingRules"]
     assert ranking_rules == new_ranking_rules
     response = await test_client.delete(f"/indexes/ranking-rules/{uid}")
-    await index.wait_for_pending_update(response.json()["updateId"])
+    await wait_for_task(index.http_client, response.json()["uid"])
     response = await test_client.get(f"/indexes/ranking-rules/{uid}")
     ranking_rules = response.json()["rankingRules"]
     assert ranking_rules == default_ranking_rules
@@ -231,7 +234,7 @@ async def test_update_distinct_attribute(test_client, empty_index, new_distinct_
     uid, index = empty_index
     data = {"uid": uid, "attribute": new_distinct_attribute}
     response = await test_client.put("/indexes/attributes/distinct", json=data)
-    await index.wait_for_pending_update(response.json()["updateId"])
+    await wait_for_task(index.http_client, response.json()["uid"])
     response = await test_client.get(f"/indexes/attributes/distinct/{uid}")
     assert response.json()["attribute"] == new_distinct_attribute
 
@@ -243,12 +246,12 @@ async def test_reset_distinct_attribute(
     uid, index = empty_index
     data = {"uid": uid, "attribute": new_distinct_attribute}
     response = await test_client.put("/indexes/attributes/distinct", json=data)
-    update = await index.wait_for_pending_update(response.json()["updateId"])
-    assert update.status == "processed"
+    update = await wait_for_task(index.http_client, response.json()["uid"])
+    assert update.status == "succeeded"
     response = await test_client.get(f"/indexes/attributes/distinct/{uid}")
     assert response.json()["attribute"] == new_distinct_attribute
     response = await test_client.delete(f"/indexes/attributes/distinct/{uid}")
-    await index.wait_for_pending_update(response.json()["updateId"])
+    await wait_for_task(index.http_client, response.json()["uid"])
     response = await test_client.get(f"/indexes/attributes/distinct/{uid}")
     assert response.json()["attribute"] == default_distinct_attribute
 
@@ -260,7 +263,7 @@ async def test_get_searchable_attributes(test_client, empty_index, small_movies)
     assert response.json()["searchableAttributes"] == ["*"]
     data = {"uid": uid, "documents": small_movies, "primaryKey": "id"}
     response = await test_client.put("/documents", json=data)
-    await index.wait_for_pending_update(response.json()["updateId"])
+    await wait_for_task(index.http_client, response.json()["uid"])
     response = await test_client.get(f"/indexes/searchable-attributes/{uid}")
     assert response.json()["searchableAttributes"] == ["*"]
 
@@ -270,7 +273,7 @@ async def test_update_searchable_attributes(test_client, empty_index, new_search
     uid, index = empty_index
     data = {"uid": uid, "searchableAttributes": new_searchable_attributes}
     response = await test_client.put("/indexes/searchable-attributes", json=data)
-    await index.wait_for_pending_update(response.json()["updateId"])
+    await wait_for_task(index.http_client, response.json()["uid"])
     response = await test_client.get(f"/indexes/searchable-attributes/{uid}")
     assert response.json()["searchableAttributes"] == new_searchable_attributes
 
@@ -280,12 +283,12 @@ async def test_reset_searchable_attributes(test_client, empty_index, new_searcha
     uid, index = empty_index
     data = {"uid": uid, "searchableAttributes": new_searchable_attributes}
     response = await test_client.put("/indexes/searchable-attributes", json=data)
-    update = await index.wait_for_pending_update(response.json()["updateId"])
-    assert update.status == "processed"
+    update = await wait_for_task(index.http_client, response.json()["uid"])
+    assert update.status == "succeeded"
     response = await test_client.get(f"/indexes/searchable-attributes/{uid}")
     assert response.json()["searchableAttributes"] == new_searchable_attributes
     response = await test_client.delete(f"/indexes/searchable-attributes/{uid}")
-    await index.wait_for_pending_update(response.json()["updateId"])
+    await wait_for_task(index.http_client, response.json()["uid"])
     response = await test_client.get(f"/indexes/searchable-attributes/{uid}")
     assert response.json()["searchableAttributes"] == ["*"]
 
@@ -297,7 +300,7 @@ async def test_get_displayed_attributes(test_client, empty_index, small_movies):
     assert response.json()["displayedAttributes"] == ["*"]
     data = {"uid": uid, "documents": small_movies}
     update = await test_client.put("/documents", json=data)
-    await index.wait_for_pending_update(update.json()["updateId"])
+    await wait_for_task(index.http_client, update.json()["uid"])
     response = await test_client.get(f"/indexes/displayed-attributes/{uid}")
     assert response.json()["displayedAttributes"] == ["*"]
 
@@ -307,7 +310,7 @@ async def test_update_displayed_attributes(test_client, empty_index, displayed_a
     uid, index = empty_index
     data = {"uid": uid, "displayedAttributes": displayed_attributes}
     response = await test_client.put("/indexes/displayed-attributes", json=data)
-    await index.wait_for_pending_update(response.json()["updateId"])
+    await wait_for_task(index.http_client, response.json()["uid"])
     response = await test_client.get(f"/indexes/displayed-attributes/{uid}")
     assert sorted(response.json()["displayedAttributes"]) == sorted(displayed_attributes)
 
@@ -317,12 +320,12 @@ async def test_reset_displayed_attributes(test_client, empty_index, displayed_at
     uid, index = empty_index
     data = {"uid": uid, "displayedAttributes": displayed_attributes}
     response = await test_client.put("/indexes/displayed-attributes", json=data)
-    update = await index.wait_for_pending_update(response.json()["updateId"])
-    assert update.status == "processed"
+    update = await wait_for_task(index.http_client, response.json()["uid"])
+    assert update.status == "succeeded"
     response = await test_client.get(f"/indexes/displayed-attributes/{uid}")
     assert sorted(response.json()["displayedAttributes"]) == sorted(displayed_attributes)
     response = await test_client.delete(f"/indexes/displayed-attributes/{uid}")
-    await index.wait_for_pending_update(response.json()["updateId"])
+    await wait_for_task(index.http_client, response.json()["uid"])
     response = await test_client.get(f"/indexes/displayed-attributes/{uid}")
     assert response.json()["displayedAttributes"] == ["*"]
 
@@ -339,8 +342,8 @@ async def test_update_stop_words(test_client, empty_index, new_stop_words):
     uid, index = empty_index
     data = {"uid": uid, "stopWords": new_stop_words}
     response = await test_client.put("/indexes/stop-words", json=data)
-    update = await index.wait_for_pending_update(response.json()["updateId"])
-    assert update.status == "processed"
+    update = await wait_for_task(index.http_client, response.json()["uid"])
+    assert update.status == "succeeded"
     response = await test_client.get(f"indexes/stop-words/{uid}")
     assert sorted(response.json()["stopWords"]) == sorted(new_stop_words)
 
@@ -350,13 +353,13 @@ async def test_reset_stop_words(test_client, empty_index, new_stop_words):
     uid, index = empty_index
     data = {"uid": uid, "stopWords": new_stop_words}
     response = await test_client.put("/indexes/stop-words", json=data)
-    update = await index.wait_for_pending_update(response.json()["updateId"])
-    assert update.status == "processed"
+    update = await wait_for_task(index.http_client, response.json()["uid"])
+    assert update.status == "succeeded"
     response = await test_client.get(f"indexes/stop-words/{uid}")
     assert sorted(response.json()["stopWords"]) == sorted(new_stop_words)
     response = await test_client.delete(f"indexes/stop-words/{uid}")
-    update = await index.wait_for_pending_update(response.json()["updateId"])
-    assert update.status == "processed"
+    update = await wait_for_task(index.http_client, response.json()["uid"])
+    assert update.status == "succeeded"
     response = await test_client.get(f"indexes/stop-words/{uid}")
     assert response.json()["stopWords"] is None
 
@@ -373,8 +376,8 @@ async def test_update_synonyms(test_client, empty_index, new_synonyms):
     uid, index = empty_index
     data = {"uid": uid, "synonyms": new_synonyms}
     response = await test_client.put("/indexes/synonyms", json=data)
-    update = await index.wait_for_pending_update(response.json()["updateId"])
-    assert update.status == "processed"
+    update = await wait_for_task(index.http_client, response.json()["uid"])
+    assert update.status == "succeeded"
     response = await test_client.get(f"/indexes/synonyms/{uid}")
     assert response.json()["synonyms"] == new_synonyms
 
@@ -392,13 +395,13 @@ async def test_reset_synonyms(test_client, empty_index, new_synonyms):
     uid, index = empty_index
     data = {"uid": uid, "synonyms": new_synonyms}
     response = await test_client.put("/indexes/synonyms", json=data)
-    update = await index.wait_for_pending_update(response.json()["updateId"])
-    assert update.status == "processed"
+    update = await wait_for_task(index.http_client, response.json()["uid"])
+    assert update.status == "succeeded"
     response = await test_client.get(f"/indexes/synonyms/{uid}")
     assert response.json()["synonyms"] == new_synonyms
     response = await test_client.delete(f"/indexes/synonyms/{uid}")
-    update = await index.wait_for_pending_update(response.json()["updateId"])
-    assert update.status == "processed"
+    update = await wait_for_task(index.http_client, response.json()["uid"])
+    assert update.status == "succeeded"
     response = await test_client.get(f"/indexes/synonyms/{uid}")
     assert response.json()["synonyms"] is None
 
@@ -415,7 +418,7 @@ async def test_update_filterable_attributes(test_client, empty_index, filterable
     uid, index = empty_index
     data = {"uid": uid, "filterableAttributes": filterable_attributes}
     response = await test_client.put("indexes/filterable-attributes", json=data)
-    await index.wait_for_pending_update(response.json()["updateId"])
+    await wait_for_task(index.http_client, response.json()["uid"])
     response = await test_client.get(f"/indexes/filterable-attributes/{uid}")
     assert sorted(response.json()["filterableAttributes"]) == filterable_attributes
 
@@ -425,12 +428,12 @@ async def test_reset_filterable_attributes(test_client, empty_index, filterable_
     uid, index = empty_index
     data = {"uid": uid, "filterableAttributes": filterable_attributes}
     response = await test_client.put("indexes/filterable-attributes", json=data)
-    update = await index.wait_for_pending_update(response.json()["updateId"])
-    assert update.status == "processed"
+    update = await wait_for_task(index.http_client, response.json()["uid"])
+    assert update.status == "succeeded"
     response = await test_client.get(f"/indexes/filterable-attributes/{uid}")
     assert sorted(response.json()["filterableAttributes"]) == filterable_attributes
     response = await test_client.delete(f"/indexes/filterable-attributes/{uid}")
-    await index.wait_for_pending_update(response.json()["updateId"])
+    await wait_for_task(index.http_client, response.json()["uid"])
     response = await test_client.get(f"/indexes/filterable-attributes/{uid}")
     assert response.json()["filterableAttributes"] is None
 
@@ -447,7 +450,7 @@ async def test_update_sortable_attributes(test_client, empty_index, sortable_att
     uid, index = empty_index
     data = {"uid": uid, "sortableAttributes": sortable_attributes}
     response = await test_client.put("indexes/sortable-attributes", json=data)
-    await index.wait_for_pending_update(response.json()["updateId"])
+    await wait_for_task(index.http_client, response.json()["uid"])
     response = await test_client.get(f"/indexes/sortable-attributes/{uid}")
     assert response.json()["sortableAttributes"] == sortable_attributes
 
@@ -457,11 +460,11 @@ async def test_reset_sortable_attributes(test_client, empty_index, sortable_attr
     uid, index = empty_index
     data = {"uid": uid, "sortableAttributes": sortable_attributes}
     response = await test_client.put("indexes/sortable-attributes", json=data)
-    update = await index.wait_for_pending_update(response.json()["updateId"])
-    assert update.status == "processed"
+    update = await wait_for_task(index.http_client, response.json()["uid"])
+    assert update.status == "succeeded"
     response = await test_client.get(f"/indexes/sortable-attributes/{uid}")
     assert response.json()["sortableAttributes"] == sortable_attributes
     response = await test_client.delete(f"/indexes/sortable-attributes/{uid}")
-    await index.wait_for_pending_update(response.json()["updateId"])
+    await wait_for_task(index.http_client, response.json()["uid"])
     response = await test_client.get(f"/indexes/sortable-attributes/{uid}")
     assert response.json()["sortableAttributes"] == []

--- a/tests/test_index_routes.py
+++ b/tests/test_index_routes.py
@@ -133,15 +133,15 @@ async def test_get_primary_key(test_client, index_uid2):
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("indexes_sample")
-async def test_delete_index(test_client, index_uid, index_uid2):
+async def test_delete_index(test_client, index_uid, index_uid2, raw_client):
     response = await test_client.delete(f"indexes/{index_uid}")
-    assert response.status_code == 204
+    await wait_for_task(raw_client.http_client, response.json()["uid"])
 
     response = await test_client.get(f"/indexes/{index_uid}")
     assert response.status_code == 404
 
     response = await test_client.delete(f"indexes/{index_uid2}")
-    assert response.status_code == 204
+    await wait_for_task(raw_client.http_client, response.json()["uid"])
 
     response = await test_client.get(f"/indexes/{index_uid2}")
     assert response.status_code == 404

--- a/tests/test_meilisearch_routes.py
+++ b/tests/test_meilisearch_routes.py
@@ -1,4 +1,37 @@
+from datetime import datetime, timedelta
+
 import pytest
+from meilisearch_python_async.errors import MeiliSearchApiError
+from meilisearch_python_async.models.client import KeyCreate
+
+
+@pytest.fixture
+@pytest.mark.asyncio
+async def test_key(raw_client):
+    key_info = KeyCreate(description="test", actions=["search"], indexes=["movies"])
+    key = await raw_client.create_key(key_info)
+
+    yield key
+
+    try:
+        await raw_client.delete_key(key.key)
+    except MeiliSearchApiError:
+        pass
+
+
+@pytest.fixture
+@pytest.mark.asyncio
+async def test_key_info(raw_client):
+    key_info = KeyCreate(description="test", actions=["search"], indexes=["movies"])
+
+    yield key_info
+
+    try:
+        keys = await raw_client.get_keys()
+        key = next(x for x in keys if x.description == key_info.description)
+        await raw_client.delete_key(key.key)
+    except MeiliSearchApiError:
+        pass
 
 
 @pytest.mark.asyncio
@@ -7,14 +40,71 @@ async def test_get_health(test_client):
     assert response.json() == {"status": "available"}
 
 
-@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "expires_at",
+    (
+        None,
+        (datetime.utcnow() + timedelta(days=2)).isoformat(),
+    ),
+)
+@pytest.mark.asyncio
+async def test_create_key(expires_at, test_client, test_key_info):
+    if expires_at:
+        test_key_info.expires_at = expires_at
+
+    key = await test_client.post("/meilisearch/keys", json=test_key_info.dict())
+    key_info = key.json()
+
+    assert key_info["description"] == test_key_info.description
+    assert key_info["actions"] == test_key_info.actions
+    assert key_info["indexes"] == test_key_info.indexes
+
+    if expires_at:
+        assert key_info["expiresAt"].split("+")[0] == expires_at.split(".")[0]
+    else:
+        assert key_info["expiresAt"] is None
+
+
+@pytest.mark.asyncio
+async def test_delete_key(test_key, test_client, raw_client):
+    result = await test_client.delete(f"/meilisearch/keys/{test_key.key}")
+    assert result.status_code == 204
+
+    with pytest.raises(MeiliSearchApiError):
+        await raw_client.get_key(test_key.key)
+
+
 @pytest.mark.asyncio
 async def test_get_keys(test_client):
     response = await test_client.get("/meilisearch/keys")
 
     assert response.status_code == 200
-    assert "public" in response.json()
-    assert "private" in response.json()
+    assert len(response.json()) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_key(test_key, test_client):
+    response = await test_client.get(f"/meilisearch/keys/{test_key.key}")
+    assert response.json()["description"] == test_key.description
+
+
+@pytest.mark.asyncio
+async def test_update_key(test_key, test_client):
+    update_key_info = {
+        "key": test_key.key,
+        "description": "updated",
+        "actions": ["*"],
+        "indexes": ["*"],
+        "expires_at": (datetime.utcnow() + timedelta(days=2)).isoformat(),
+    }
+
+    key = await test_client.patch(f"meilisearch/keys/{test_key.key}", json=update_key_info)
+    key_info = key.json()
+
+    assert key_info["description"] == update_key_info["description"]
+    assert key_info["actions"] == update_key_info["actions"]
+    assert key_info["indexes"] == update_key_info["indexes"]
+    assert key_info["expiresAt"].split("+")[0] == update_key_info["expires_at"].split(".")[0]
 
 
 @pytest.mark.asyncio

--- a/tests/test_meilisearch_routes.py
+++ b/tests/test_meilisearch_routes.py
@@ -7,6 +7,7 @@ async def test_get_health(test_client):
     assert response.json() == {"status": "available"}
 
 
+@pytest.mark.xfail
 @pytest.mark.asyncio
 async def test_get_keys(test_client):
     response = await test_client.get("/meilisearch/keys")

--- a/tests/test_search_routes.py
+++ b/tests/test_search_routes.py
@@ -1,4 +1,5 @@
 import pytest
+from meilisearch_python_async.task import wait_for_task
 
 
 @pytest.mark.asyncio
@@ -106,7 +107,7 @@ async def test_custom_search_params_with_facets_distribution(test_client, index_
     uid, index = index_with_documents
     facet_data = {"uid": uid, "filterableAttributes": ["genre"]}
     update = await test_client.put("/indexes/filterable-attributes", json=facet_data)
-    await index.wait_for_pending_update(update.json()["updateId"])
+    await wait_for_task(index.http_client, update.json()["uid"])
     data = {
         "uid": uid,
         "query": "world",
@@ -127,7 +128,7 @@ async def test_custom_search_params_with_facet_filters(test_client, index_with_d
     uid, index = index_with_documents
     facet_data = {"uid": uid, "filterableAttributes": ["genre"]}
     update = await test_client.put("/indexes/filterable-attributes", json=facet_data)
-    await index.wait_for_pending_update(update.json()["updateId"])
+    await wait_for_task(index.http_client, update.json()["uid"])
     data = {
         "uid": uid,
         "query": "world",
@@ -145,7 +146,7 @@ async def test_custom_search_params_with_multiple_facet_filters(test_client, ind
     uid, index = index_with_documents
     facet_data = {"uid": uid, "filterableAttributes": ["genre"]}
     update = await test_client.put("/indexes/filterable-attributes", json=facet_data)
-    await index.wait_for_pending_update(update.json()["updateId"])
+    await wait_for_task(index.http_client, update.json()["uid"])
     data = {
         "uid": uid,
         "query": "world",
@@ -205,10 +206,10 @@ async def test_custom_search_facet_filters_with_space(test_client, empty_index):
         "documents": dataset,
     }
     update = await test_client.post("/documents", json=documents)
-    await index.wait_for_pending_update(update.json()["updateId"])
+    await wait_for_task(index.http_client, update.json()["uid"])
     facet_data = {"uid": uid, "filterableAttributes": ["genre"]}
     update = await test_client.put("/indexes/filterable-attributes", json=facet_data)
-    await index.wait_for_pending_update(update.json()["updateId"])
+    await wait_for_task(index.http_client, update.json()["uid"])
     data = {
         "uid": uid,
         "query": "h",
@@ -224,7 +225,7 @@ async def test_custom_search_params_with_many_params(test_client, index_with_doc
     uid, index = index_with_documents
     facet_data = {"uid": uid, "filterableAttributes": ["genre"]}
     update = await test_client.put("/indexes/filterable-attributes", json=facet_data)
-    await index.wait_for_pending_update(update.json()["updateId"])
+    await wait_for_task(index.http_client, update.json()["uid"])
     data = {
         "uid": uid,
         "query": "world",
@@ -259,7 +260,7 @@ async def test_custom_search_params_with_many_params(test_client, index_with_doc
 async def test_search_sort(sort, titles, test_client, index_with_documents):
     uid, index = index_with_documents
     response = await index.update_sortable_attributes(["title"])
-    await index.wait_for_pending_update(response.update_id)
+    await wait_for_task(index.http_client, response.uid)
     stats = await index.get_stats()  # get this to get the total document count
 
     # Using a placeholder search because ranking rules affect sort otherwaise meaning the results

--- a/tests/test_settings_routes.py
+++ b/tests/test_settings_routes.py
@@ -15,14 +15,16 @@ def default_settings():
     }
 
 
+@pytest.mark.usefixtures("indexes_sample")
 @pytest.mark.asyncio
-async def test_settings_get(default_settings, index_uid, indexes_sample, test_client):
+async def test_settings_get(default_settings, index_uid, test_client):
     response = await test_client.get(f"/settings/{index_uid}")
 
     assert response.status_code == 200
     assert response.json() == default_settings
 
 
+@pytest.mark.usefixtures("indexes_sample")
 @pytest.mark.asyncio
 async def test_settings_update_and_delete(default_settings, index_uid, test_client):
     update_settings = {


### PR DESCRIPTION
## Features

- Routes added for new auth keys

## Breaking

- Routes that used to return an UpdateId now return a TaskId
- Update Index route now returns TaskId
- `get_keys` not returns a list of Keys