### PR TITLE
Change config to use standard MeiliSearch environment variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ api_router.include_router(settings_routes.router, prefix="/settings", dependeinc
 app.include_router(api_router)
 ```
 
-The url for MeiliSearch and API key are read from environment variables. Putting these into a .env
-file will keep you from having to set these variables each time the terminal is restarted.
+The url for MeiliSearch, weather an https address should be used, and API key are read from
+environment variables. Putting these into a .env file will keep you from having to set these
+variables each time the terminal is restarted.
 
 ```txt
-MEILISEARCH_URL=http://localhost:7700  # This is the url for your instance of MeiliSearch
-MEILISEARCH_API_KEY=masterKey  # This is the API key for your MeiliSearch instance
+MEILI_HTTP_ADDR=localhost:7700  # This is the url for your instance of MeiliSearch
+MEILI_HTTPS_URL=true  # Setting this specifies the address should be https://. If false or not included the address will be http://
+MEILI_MASTER_KEY=masterKey  # This is the API key for your MeiliSearch instance
 ```
 
 Now the MeiliSearch routes will be available in your FastAPI app. Documentation for the routes can be viewed in the OpenAPI documentation of the FastAPI app. To view this start your FastAPI app and naviate to the docs `http://localhost:8000/docs` replacing the url with the correct url for your app.

--- a/meilisearch_fastapi/_config.py
+++ b/meilisearch_fastapi/_config.py
@@ -1,17 +1,32 @@
 from functools import lru_cache
-from typing import Optional
+from typing import Any, Dict, Optional
 
-from pydantic import BaseSettings
+from pydantic import BaseSettings, Field, root_validator
+from pydantic.error_wrappers import ValidationError
 
 
 class MeiliSearchConfig(BaseSettings):
-    meilisearch_url: str
-    meilisearch_api_key: Optional[str] = None
+    meili_http_addr: str = Field(..., env="MEILI_HTTP_ADDR")
+    meili_https_url: bool = Field(False, env="MEILI_HTTPS_URL")
+    meilisearch_url: str = "http://localhost:7700"
+    meilisearch_api_key: Optional[str] = Field(None, env="MEILI_MASTER_KEY")
+
+    @root_validator
+    def set_url(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if not values.get("meili_http_addr"):
+            raise ValidationError("A MEILI_HTTP_ADDR value is required", MeiliSearchConfig)
+
+        if values["meili_https_url"]:
+            values["meilisearch_url"] = f"https://{values['meili_http_addr']}"
+            return values
+
+        values["meilisearh_url"] = f"http://{values['meili_http_addr']}"
+        return values
 
     class Config:
         env_file = ".env"
 
 
-@lru_cache()
+@lru_cache(maxsize=1)
 def get_config() -> MeiliSearchConfig:
     return MeiliSearchConfig()


### PR DESCRIPTION
`MEILI_HTTPS_URL` environment variable added to specify if `https` should be used for the address.

## Breaking

- `MEILISEARCH_URL` environment variable renamed to `MEILI_HTTP_ADDR`
- `MEILISEARCH_API_KEY` environment variable renamed to `MEILI_MASTER_KEY`