### PR TITLE
Make compatible with Meilisearch v1.1.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
     - name: Install Dependencies
       run: poetry install
     - name: MeiliSearch (latest version) setup with Docker
-      run: docker run -d -p 7700:7700 getmeili/meilisearch:v0.28.1 meilisearch --no-analytics --master-key=masterKey
+      run: docker run -d -p 7700:7700 getmeili/meilisearch:v1.1.0 meilisearch --no-analytics --master-key=masterKey
     - name: Test with pytest
       run: |
         poetry run pytest --cov=meilisearch_fastapi --cov-report=xml

--- a/meilisearch_fastapi/_config.py
+++ b/meilisearch_fastapi/_config.py
@@ -5,7 +5,7 @@ from pydantic import BaseSettings, Field, root_validator
 from pydantic.error_wrappers import ValidationError
 
 
-class MeiliSearchConfig(BaseSettings):
+class MeilisearchConfig(BaseSettings):
     meili_http_addr: str = Field(..., env="MEILI_HTTP_ADDR")
     meili_https_url: bool = Field(False, env="MEILI_HTTPS_URL")
     meilisearch_url: str = "http://localhost:7700"
@@ -14,7 +14,7 @@ class MeiliSearchConfig(BaseSettings):
     @root_validator
     def set_url(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         if not values.get("meili_http_addr"):
-            raise ValidationError("A MEILI_HTTP_ADDR value is required", MeiliSearchConfig)
+            raise ValidationError("A MEILI_HTTP_ADDR value is required", MeilisearchConfig)
 
         if values["meili_https_url"]:
             values["meilisearch_url"] = f"https://{values['meili_http_addr']}"
@@ -28,5 +28,5 @@ class MeiliSearchConfig(BaseSettings):
 
 
 @lru_cache(maxsize=1)
-def get_config() -> MeiliSearchConfig:
-    return MeiliSearchConfig()  # type: ignore[call-arg]
+def get_config() -> MeilisearchConfig:
+    return MeilisearchConfig()  # type: ignore[call-arg]

--- a/meilisearch_fastapi/models/document_info.py
+++ b/meilisearch_fastapi/models/document_info.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from camel_converter.pydantic_base import CamelBase
 
@@ -10,7 +10,7 @@ class DocumentDelete(CamelBase):
 
 class DocumentInfo(CamelBase):
     uid: str
-    documents: List[Dict]
+    documents: List[Dict[str, Any]]
     primary_key: Optional[str] = None
 
 

--- a/meilisearch_fastapi/models/settings.py
+++ b/meilisearch_fastapi/models/settings.py
@@ -1,5 +1,5 @@
-from meilisearch_python_async.models.settings import MeiliSearchSettings
+from meilisearch_python_async.models.settings import MeilisearchSettings
 
 
-class MeiliSearchIndexSettings(MeiliSearchSettings):
+class MeilisearchIndexSettings(MeilisearchSettings):
     uid: str

--- a/meilisearch_fastapi/routes/document_routes.py
+++ b/meilisearch_fastapi/routes/document_routes.py
@@ -15,7 +15,7 @@ from meilisearch_fastapi.models.document_info import (
 router = APIRouter()
 
 
-@router.post("/", response_model=TaskInfo, status_code=202, tags=["MeiliSearch Documents"])
+@router.post("/", response_model=TaskInfo, status_code=202, tags=["Meilisearch Documents"])
 async def add_documents(
     document_info: DocumentInfo,
     client: Client = Depends(meilisearch_client),
@@ -26,7 +26,7 @@ async def add_documents(
 
 
 @router.post(
-    "/batches", response_model=List[TaskInfo], status_code=202, tags=["MeiliSearch Documents"]
+    "/batches", response_model=List[TaskInfo], status_code=202, tags=["Meilisearch Documents"]
 )
 async def add_documents_in_batches(
     document_info: DocumentInfoBatches, client: Client = Depends(meilisearch_client)
@@ -40,7 +40,7 @@ async def add_documents_in_batches(
     )
 
 
-@router.delete("/{uid}", response_model=TaskInfo, status_code=202, tags=["MeiliSearch Documents"])
+@router.delete("/{uid}", response_model=TaskInfo, status_code=202, tags=["Meilisearch Documents"])
 async def delete_all_documents(uid: str, client: Client = Depends(meilisearch_client)) -> TaskInfo:
     index = client.index(uid)
 
@@ -51,7 +51,7 @@ async def delete_all_documents(uid: str, client: Client = Depends(meilisearch_cl
     "/{uid}/{document_id}",
     response_model=TaskInfo,
     status_code=202,
-    tags=["MeiliSearch Documents"],
+    tags=["Meilisearch Documents"],
 )
 async def delete_document(
     uid: str, document_id: str, client: Client = Depends(meilisearch_client)
@@ -61,7 +61,7 @@ async def delete_document(
     return await index.delete_document(document_id)
 
 
-@router.post("/delete", response_model=TaskInfo, status_code=202, tags=["MeiliSearch Documents"])
+@router.post("/delete", response_model=TaskInfo, status_code=202, tags=["Meilisearch Documents"])
 async def delete_documents(
     documents: DocumentDelete,
     client: Client = Depends(meilisearch_client),
@@ -71,7 +71,7 @@ async def delete_documents(
     return await index.delete_documents(documents.document_ids)
 
 
-@router.get("/{uid}/{document_id}", response_model=dict, tags=["MeiliSearch Documents"])
+@router.get("/{uid}/{document_id}", response_model=dict, tags=["Meilisearch Documents"])
 async def get_document(
     uid: str,
     document_id: str,
@@ -82,7 +82,7 @@ async def get_document(
     return await index.get_document(document_id)
 
 
-@router.get("/{uid}", response_model=DocumentsInfo, tags=["MeiliSearch Documents"])
+@router.get("/{uid}", response_model=DocumentsInfo, tags=["Meilisearch Documents"])
 async def get_documents(
     uid: str,
     limit: int = 20,
@@ -101,7 +101,7 @@ async def get_documents(
     return documents
 
 
-@router.put("/", response_model=TaskInfo, status_code=202, tags=["MeiliSearch Documents"])
+@router.put("/", response_model=TaskInfo, status_code=202, tags=["Meilisearch Documents"])
 async def update_documents(
     document_info: DocumentInfo,
     client: Client = Depends(meilisearch_client),
@@ -112,7 +112,7 @@ async def update_documents(
 
 
 @router.put(
-    "/batches", response_model=List[TaskInfo], status_code=202, tags=["MeiliSearch Documents"]
+    "/batches", response_model=List[TaskInfo], status_code=202, tags=["Meilisearch Documents"]
 )
 async def update_documents_in_batches(
     document_info: DocumentInfoBatches,

--- a/meilisearch_fastapi/routes/index_routes.py
+++ b/meilisearch_fastapi/routes/index_routes.py
@@ -8,7 +8,7 @@ from meilisearch_python_async.models.task import TaskInfo
 from starlette.status import HTTP_202_ACCEPTED, HTTP_204_NO_CONTENT
 
 from meilisearch_fastapi._client import meilisearch_client
-from meilisearch_fastapi._config import MeiliSearchConfig, get_config
+from meilisearch_fastapi._config import MeilisearchConfig, get_config
 from meilisearch_fastapi.models.index import (
     DisplayedAttributes,
     DisplayedAttributesUID,
@@ -394,7 +394,7 @@ async def update_distinct_attribute(
 async def update_index(
     index_update: IndexUpdate,
     client: Client = Depends(meilisearch_client),
-    config: MeiliSearchConfig = Depends(get_config),
+    config: MeilisearchConfig = Depends(get_config),
 ) -> TaskInfo:
     payload = {}
     if index_update.primary_key is not None:

--- a/meilisearch_fastapi/routes/meilisearch_routes.py
+++ b/meilisearch_fastapi/routes/meilisearch_routes.py
@@ -12,7 +12,7 @@ from meilisearch_fastapi.models.tenant_token import TenantToken, TenantTokenSett
 router = APIRouter()
 
 
-@router.post("/generate-tenant-token", response_model=TenantToken, tags=["MeiliSearch"])
+@router.post("/generate-tenant-token", response_model=TenantToken, tags=["Meilisearch"])
 async def generate_tenant_token(
     tenant_token_settings: TenantTokenSettings, client: Client = Depends(meilisearch_client)
 ) -> TenantToken:
@@ -30,43 +30,43 @@ async def generate_tenant_token(
     return TenantToken(tenant_token=token)
 
 
-@router.get("/health", response_model=Health, tags=["MeiliSearch"])
+@router.get("/health", response_model=Health, tags=["Meilisearch"])
 async def get_health(client: Client = Depends(meilisearch_client)) -> Health:
     return await client.health()
 
 
-@router.post("/keys", response_model=Key, tags=["MeiliSearch"])
+@router.post("/keys", response_model=Key, tags=["Meilisearch"])
 async def create_key(key: KeyCreate, client: Client = Depends(meilisearch_client)) -> Key:
     return await client.create_key(key)
 
 
-@router.delete("/keys/{key}", status_code=HTTP_204_NO_CONTENT, tags=["MeiliSearch"])
+@router.delete("/keys/{key}", status_code=HTTP_204_NO_CONTENT, tags=["Meilisearch"])
 async def delete_key(key: str, client: Client = Depends(meilisearch_client)) -> None:
     await client.delete_key(key)
 
 
-@router.get("/keys", response_model=KeySearch, tags=["MeiliSearch"])
+@router.get("/keys", response_model=KeySearch, tags=["Meilisearch"])
 async def get_keys(client: Client = Depends(meilisearch_client)) -> KeySearch:
     return await client.get_keys()
 
 
-@router.get("/keys/{key}", response_model=Key, tags=["MeiliSearch"])
+@router.get("/keys/{key}", response_model=Key, tags=["Meilisearch"])
 async def get_key(key: str, client: Client = Depends(meilisearch_client)) -> Key:
     return await client.get_key(key)
 
 
-@router.patch("/keys/{key}", response_model=Key, tags=["MeiliSearch"])
+@router.patch("/keys/{key}", response_model=Key, tags=["Meilisearch"])
 async def update_key(
     key: str, update_key: KeyUpdate, client: Client = Depends(meilisearch_client)
 ) -> Key:
     return await client.update_key(update_key)
 
 
-@router.get("/stats", response_model=ClientStats, tags=["MeiliSearch"])
+@router.get("/stats", response_model=ClientStats, tags=["Meilisearch"])
 async def get_stats(client: Client = Depends(meilisearch_client)) -> ClientStats:
     return await client.get_all_stats()
 
 
-@router.get("/version", response_model=Version, tags=["MeiliSearch"])
+@router.get("/version", response_model=Version, tags=["Meilisearch"])
 async def get_version(client: Client = Depends(meilisearch_client)) -> Version:
     return await client.get_version()

--- a/meilisearch_fastapi/routes/search_routes.py
+++ b/meilisearch_fastapi/routes/search_routes.py
@@ -8,7 +8,7 @@ from meilisearch_fastapi.models.search_parameters import SearchParameters
 router = APIRouter()
 
 
-@router.post("/", response_model=SearchResults, tags=["MeiliSearch Search"])
+@router.post("/", response_model=SearchResults, tags=["Meilisearch Search"])
 async def search(
     search_parameters: SearchParameters, client: Client = Depends(meilisearch_client)
 ) -> SearchResults:

--- a/meilisearch_fastapi/routes/settings_routes.py
+++ b/meilisearch_fastapi/routes/settings_routes.py
@@ -1,29 +1,29 @@
 from fastapi import APIRouter, Depends
 from meilisearch_python_async import Client
-from meilisearch_python_async.models.settings import MeiliSearchSettings
+from meilisearch_python_async.models.settings import MeilisearchSettings
 from meilisearch_python_async.models.task import TaskInfo
 
 from meilisearch_fastapi._client import meilisearch_client
-from meilisearch_fastapi._config import MeiliSearchConfig, get_config
-from meilisearch_fastapi.models.settings import MeiliSearchIndexSettings
+from meilisearch_fastapi._config import MeilisearchConfig, get_config
+from meilisearch_fastapi.models.settings import MeilisearchIndexSettings
 
 router = APIRouter()
 
 
-@router.get("/{uid}", response_model=MeiliSearchSettings, tags=["MeiliSearch Settings"])
+@router.get("/{uid}", response_model=MeilisearchSettings, tags=["Meilisearch Settings"])
 async def get_settings(
     uid: str, client: Client = Depends(meilisearch_client)
-) -> MeiliSearchSettings:
+) -> MeilisearchSettings:
     index = client.index(uid)
 
     return await index.get_settings()
 
 
-@router.delete("/{uid}", response_model=TaskInfo, tags=["MeiliSearch Settings"])
+@router.delete("/{uid}", response_model=TaskInfo, tags=["Meilisearch Settings"])
 async def delete_settings(
     uid: str,
     client: Client = Depends(meilisearch_client),
-    config: MeiliSearchConfig = Depends(get_config),
+    config: MeilisearchConfig = Depends(get_config),
 ) -> TaskInfo:
     async with Client(url=config.meilisearch_url, api_key=config.meilisearch_api_key) as client:
         index = client.index(uid)
@@ -31,13 +31,13 @@ async def delete_settings(
         return await index.reset_settings()
 
 
-@router.patch("/", response_model=TaskInfo, tags=["MeiliSearch Settings"])
+@router.patch("/", response_model=TaskInfo, tags=["Meilisearch Settings"])
 async def update_settings(
-    update_settings: MeiliSearchIndexSettings, client: Client = Depends(meilisearch_client)
+    update_settings: MeilisearchIndexSettings, client: Client = Depends(meilisearch_client)
 ) -> TaskInfo:
     index = client.index(update_settings.uid)
 
-    meili_settings = MeiliSearchSettings(
+    meili_settings = MeilisearchSettings(
         synonyms=update_settings.synonyms,
         stop_words=update_settings.stop_words,
         ranking_rules=update_settings.ranking_rules,

--- a/poetry.lock
+++ b/poetry.lock
@@ -430,22 +430,22 @@ files = [
 
 [[package]]
 name = "meilisearch-python-async"
-version = "0.26.0"
+version = "1.1.1"
 description = "A Python async client for the Meilisearch API"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "meilisearch-python-async-0.26.0.tar.gz", hash = "sha256:6463f3b69a04adfbd85c7a661e0050b14d44b3fd1310404db7529916abb38cb4"},
-    {file = "meilisearch_python_async-0.26.0-py3-none-any.whl", hash = "sha256:434b3deaf95382fe7e35bab019c4617650c0e37ba45a0ff540e367921ea2e7b9"},
+    {file = "meilisearch_python_async-1.1.1-py3-none-any.whl", hash = "sha256:a60ef9c4f4864c0244010fefdeb6986d0d7c71efb0da911b2acd0cec68906579"},
+    {file = "meilisearch_python_async-1.1.1.tar.gz", hash = "sha256:7c16e226a67b2a8231cc4df05e819969442a2d41164cdb50273f9c586824058b"},
 ]
 
 [package.dependencies]
-aiofiles = ">=0.7,<0.9"
-camel-converter = ">=1.0.0,<2.0.0"
-httpx = ">=0.17,<0.24"
-pydantic = ">=1.8,<2.0"
-PyJWT = ">=2.3.0,<3.0.0"
+aiofiles = ">=0.7"
+camel-converter = ">=1.0.0"
+httpx = ">=0.17"
+pydantic = ">=1.8"
+PyJWT = ">=2.3.0"
 
 [[package]]
 name = "mypy"
@@ -1066,4 +1066,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "bc960c249bbf557da766a624955ca67f72eb70565eb4ca9aa35a787fb628d7f2"
+content-hash = "e6caf495c2ab5a78b58e9ac70969758c8b271814be4f58ce4e7ea2ac57d169dc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ include = ["meilisearch_fastapi/py.typed"]
 python = "^3.7"
 fastapi = ">=0.95.1"
 pydantic = {version = ">=1.8.2", extras = ["dotenv"]}
-meilisearch-python-async = "0.26.0"
+meilisearch-python-async = ">=1.1.1"
 
 [tool.poetry.group.dev.dependencies]
 black = ">=22.8.0"

--- a/tests/test_document_routes.py
+++ b/tests/test_document_routes.py
@@ -136,10 +136,11 @@ async def test_update_documents(test_client, index_with_documents, small_movies)
     response = await test_client.get(f"documents/{uid}")
     response_docs = response.json()["results"]
     response_docs[0]["title"] = "Some title"
+    doc_id = response_docs[0]["id"]
     update_body = {"uid": uid, "documents": response_docs}
     update = await test_client.put("/documents", json=update_body)
     await wait_for_task(index.http_client, update.json()["taskUid"])
-    response = await test_client.get(f"/documents/{uid}")
+    response = await test_client.get(f"/document/{uid}/{doc_id}")
     assert response.json()["results"][0]["title"] == "Some title"
     update_body = {"uid": uid, "documents": small_movies}
     update = await test_client.put("/documents", json=update_body)

--- a/tests/test_document_routes.py
+++ b/tests/test_document_routes.py
@@ -140,13 +140,13 @@ async def test_update_documents(test_client, index_with_documents, small_movies)
     update_body = {"uid": uid, "documents": response_docs}
     update = await test_client.put("/documents", json=update_body)
     await wait_for_task(index.http_client, update.json()["taskUid"])
-    response = await test_client.get(f"/document/{uid}/{doc_id}")
-    assert response.json()["results"][0]["title"] == "Some title"
+    response = await test_client.get(f"/documents/{uid}/{doc_id}")
+    assert response.json()["title"] == "Some title"
     update_body = {"uid": uid, "documents": small_movies}
     update = await test_client.put("/documents", json=update_body)
     await wait_for_task(index.http_client, update.json()["taskUid"])
-    response = await test_client.get(f"/documents/{uid}")
-    assert response.json()["results"][0]["title"] != "Some title"
+    response = await test_client.get(f"/documents/{uid}/{doc_id}")
+    assert response.json()["title"] != "Some title"
 
 
 async def test_update_documents_with_primary_key(test_client, empty_index, small_movies):
@@ -166,16 +166,17 @@ async def test_update_documents_in_batches(
     response = await test_client.get(f"documents/{uid}")
     response_docs = response.json()["results"]
     response_docs[0]["title"] = "Some title"
+    doc_id = response_docs[0]["id"]
     update_body = {"uid": uid, "documents": response_docs}
     update = await test_client.put("/documents", json=update_body)
     await wait_for_task(index.http_client, update.json()["taskUid"])
-    response = await test_client.get(f"/documents/{uid}")
-    assert response.json()["results"][0]["title"] == "Some title"
+    response = await test_client.get(f"/documents/{uid}/{doc_id}")
+    assert response.json()["title"] == "Some title"
     update_body = {"uid": uid, "batch_size": batch_size, "documents": small_movies}
     updates = await test_client.put("/documents/batches", json=update_body)
 
     for update in updates.json():
         await wait_for_task(index.http_client, update["taskUid"])
 
-    response = await test_client.get(f"/documents/{uid}")
-    assert response.json()["results"][0]["title"] != "Some title"
+    response = await test_client.get(f"/documents/{uid}/{doc_id}")
+    assert response.json()["title"] != "Some title"

--- a/tests/test_document_routes.py
+++ b/tests/test_document_routes.py
@@ -1,7 +1,7 @@
 from math import ceil
 
 import pytest
-from meilisearch_python_async.errors import MeiliSearchApiError
+from meilisearch_python_async.errors import MeilisearchApiError
 from meilisearch_python_async.task import wait_for_task
 
 
@@ -71,7 +71,7 @@ async def test_delete_document(test_client, index_with_documents):
     uid, index = index_with_documents
     response = await test_client.delete(f"/documents/{uid}/500682")
     await wait_for_task(index.http_client, response.json()["taskUid"])
-    with pytest.raises(MeiliSearchApiError):
+    with pytest.raises(MeilisearchApiError):
         await test_client.get(f"/documents/{uid}/500682")
 
 
@@ -104,7 +104,7 @@ async def test_get_document(test_client, index_with_documents):
 
 
 async def test_get_document_nonexistent(test_client, empty_index):
-    with pytest.raises(MeiliSearchApiError):
+    with pytest.raises(MeilisearchApiError):
         uid, _ = empty_index
         await test_client.get(f"documents/{uid}/123")
 

--- a/tests/test_index_routes.py
+++ b/tests/test_index_routes.py
@@ -1,11 +1,11 @@
 import pytest
-from meilisearch_python_async.models.settings import MeiliSearchSettings
+from meilisearch_python_async.models.settings import MeilisearchSettings
 from meilisearch_python_async.task import wait_for_task
 
 
 @pytest.fixture
 def new_settings():
-    return MeiliSearchSettings(
+    return MeilisearchSettings(
         ranking_rules=["typo", "words"], searchable_attributes=["title", "overview"]
     )
 

--- a/tests/test_meilisearch_routes.py
+++ b/tests/test_meilisearch_routes.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 import jwt
 import pytest
-from meilisearch_python_async.errors import MeiliSearchApiError
+from meilisearch_python_async.errors import MeilisearchApiError
 from meilisearch_python_async.models.client import KeyCreate
 
 
@@ -15,7 +15,7 @@ async def test_key(raw_client):
 
     try:
         await raw_client.delete_key(key.key)
-    except MeiliSearchApiError:
+    except MeilisearchApiError:
         pass
 
 
@@ -29,7 +29,7 @@ async def test_key_info(raw_client):
         keys = await raw_client.get_keys()
         key = next(x for x in keys.results if x.description == key_info.description)
         await raw_client.delete_key(key.key)
-    except MeiliSearchApiError:
+    except MeilisearchApiError:
         pass
 
 
@@ -130,7 +130,7 @@ async def test_delete_key(test_key, test_client, raw_client):
     result = await test_client.delete(f"/meilisearch/keys/{test_key.key}")
     assert result.status_code == 204
 
-    with pytest.raises(MeiliSearchApiError):
+    with pytest.raises(MeilisearchApiError):
         await raw_client.get_key(test_key.key)
 
 

--- a/tests/test_settings_routes.py
+++ b/tests/test_settings_routes.py
@@ -9,7 +9,6 @@ def default_settings():
         "stopWords": [],
         "rankingRules": ["words", "typo", "proximity", "attribute", "sort", "exactness"],
         "filterableAttributes": [],
-        "faceting": {"maxValuesPerFacet": 100},
         "distinctAttribute": None,
         "searchableAttributes": ["*"],
         "displayedAttributes": ["*"],
@@ -20,6 +19,8 @@ def default_settings():
             "disableOnWords": [],
             "minWordSizeForTypos": {"oneTypo": 5, "twoTypos": 9},
         },
+        "faceting": {"maxValuesPerFacet": 100},
+        "pagination": {"maxTotalHits": 1000},
     }
 
 
@@ -47,6 +48,7 @@ async def test_settings_update_and_delete(default_settings, index_uid, test_clie
         "typoTolerance": {
             "enabled": False,
         },
+        "pagination": {"maxTotalHits": 1000},
     }
     response = await test_client.patch("/settings", json=update_settings)
 


### PR DESCRIPTION
- Bumps `meilisearch-python-async` to `v1.1.0`
- Rename `MeiliSearch` to `Meilisearch` in all instances
- Bump Meilisearch to `v1.1.0` in CI
- Add support for Meilisearch v1.1.0